### PR TITLE
Add hack solution for multiple selectors

### DIFF
--- a/lib/floki/matchers.ex
+++ b/lib/floki/matchers.ex
@@ -57,9 +57,19 @@ defmodule Floki.Matchers do
   end
 
   def value_match?(attribute_value, selector_value) do
-    attribute_value
-    |> String.split
-    |> Enum.any?(fn(x) -> x == selector_value end)
+    selector_values = String.split(selector_value, ~r/[#.]/)
+
+    if length(selector_values) == 1 do
+      attribute_value
+      |> String.split
+      |> Enum.any?(fn(x) -> x == selector_value end)
+    else
+      attribute_value
+      |> String.split
+      |> Enum.all?(fn(x) ->
+        Enum.find(selector_values, fn(y) -> y == x end)
+      end)
+    end
   end
 
   def attribute_match?(attributes, attribute_name) do

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -162,6 +162,17 @@ defmodule FlokiTest do
     ]
   end
 
+  test "find elements with multiple given classes" do
+    class_selector = ".js-cool.js-elixir"
+
+    assert Floki.find(@html, class_selector) == [
+      {"a", [
+          {"href", "http://elixir-lang.org"},
+          {"class", "js-elixir js-cool"}],
+        ["Elixir lang"]}
+    ]
+  end
+
   test "find element that does not have child node" do
     class_selector = ".js-twitter-logo"
 


### PR DESCRIPTION
This is a pretty gross solution for multiple selectors. I don't have a full understanding of the `Floki.Matchers` module, but I'm thinking that a full solution would involve creating a more robust representation of a selector, instead of just treating it as a string.

Closes #18 