### PR TITLE
Update mix.exs to include :mochiweb in application configuration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Floki.Mixfile do
   end
 
   def application do
-    []
+    [applications: [:mochiweb]]
   end
 
   defp deps do


### PR DESCRIPTION
Since `mochiweb` is a runtime dependency, it needs to be included in the application config when using exrm releases. Here's the error I was getting on my server if I didn't put `:mochiweb` in my own app's config.

```
** (exit) an exception was raised:
    ** (ErlangError) erlang error: :"module could not be loaded"
        :mochiweb_html.parse("<floki><!DOCTYPE html PUBLI….
```
