### PR TITLE
Fix compilation on Erlang 17.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: elixir
 elixir:
-  - 1.0.3
   - 1.0.4
+  - 1.0.5
 otp_release:
   - 17.0
   - 17.3
+  - 17.4
+  - 17.5
+  - 18.0
+
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Floki.Mixfile do
     %{
       contributors: ["Philip Sampaio Silva"],
       licenses: ["MIT"],
-      files: ["lib", "priv", "src", "mix.exs", "README*", "readme*", "LICENSE*", "license*"],
+      files: ["lib", "priv", "src/*.xrl", "mix.exs", "README*", "readme*", "LICENSE*", "license*"],
       links: %{
         "GitHub" => "https://github.com/philss/floki",
         "Docs"   => "http://hexdocs.pm/floki"


### PR DESCRIPTION
This PR excludes the `src/*.erl` files from package generation by only reading the `src/*.xrl` files.

This is needed because we shouldn't include the compiled lexer in the new packages.

Fixes #24 