### PR TITLE
Add adjacent sibling selector

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -78,8 +78,7 @@ defmodule Floki do
   end
 
   @doc """
-  Finds elements inside a HTML tree or string.
-  You can search by class, tag name or id.
+  Find elements inside a HTML tree or string.
 
   ## Examples
 
@@ -97,10 +96,10 @@ defmodule Floki do
   @spec find(binary | html_tree, binary) :: html_tree
 
   def find(html, selector) when is_binary(html) do
-    Floki.Parser.parse(html) |> Finder.find(selector)
+    parse(html) |> Finder.find(selector)
   end
-  def find(html, selector) do
-    Finder.find(html, selector)
+  def find(html_tree, selector) do
+    Finder.find(html_tree, selector)
   end
 
   @doc """

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -3,15 +3,16 @@ defmodule Floki.Selector do
   alias Floki.AttributeSelector
 
   defstruct id: nil,
-            type: nil,
-            classes: [],
-            attributes: [],
-            combinator: nil
+  type: nil,
+  classes: [],
+  attributes: [],
+  combinator: nil
 
   def match?(_node, %Selector{id: nil, type: nil, classes: [], attributes: []}) do
     false
   end
 
+  def match?(nil, _selector), do: false
   def match?({:comment, _comment}, _selector), do: false
   def match?({:pi, _xml, _xml_attrs}, _selector), do: false
 
@@ -22,39 +23,39 @@ defmodule Floki.Selector do
     attributes_matches?(node, selector.attributes)
   end
 
-   defp id_match?(_node, nil), do: true
-   defp id_match?({_, [], _}, _), do: false
-   defp id_match?({_, attributes, _}, id) do
-     Enum.any? attributes, fn(attribute) ->
-       case attribute do
-         {"id", ^id} -> true
-         _ -> false
-       end
-     end
-   end
+  defp id_match?(_node, nil), do: true
+  defp id_match?({_, [], _}, _), do: false
+  defp id_match?({_, attributes, _}, id) do
+    Enum.any? attributes, fn(attribute) ->
+      case attribute do
+        {"id", ^id} -> true
+        _ -> false
+      end
+    end
+  end
 
-   defp type_match?(_node, nil), do: true
-   defp type_match?({type, _, _}, type), do: true
-   defp type_match?({_type, _, _}, "*"), do: true
-   defp type_match?(_, _), do: false
+  defp type_match?(_node, nil), do: true
+  defp type_match?({type, _, _}, type), do: true
+  defp type_match?({_type, _, _}, "*"), do: true
+  defp type_match?(_, _), do: false
 
-   defp classes_matches?(_node, []), do: true
-   defp classes_matches?({_, [], _}, _), do: false
-   defp classes_matches?({_, attributes, _}, classes) do
-     Enum.all? classes, fn(class) ->
-       selector = %AttributeSelector{match_type: :includes,
-                                     attribute: "class",
-                                     value: class}
+  defp classes_matches?(_node, []), do: true
+  defp classes_matches?({_, [], _}, _), do: false
+  defp classes_matches?({_, attributes, _}, classes) do
+    Enum.all? classes, fn(class) ->
+      selector = %AttributeSelector{match_type: :includes,
+        attribute: "class",
+        value: class}
 
-       AttributeSelector.match?(attributes, selector)
-     end
-   end
+      AttributeSelector.match?(attributes, selector)
+    end
+  end
 
-   defp attributes_matches?(_node, []), do: true
-   defp attributes_matches?({_, [], _}, _), do: false
-   defp attributes_matches?({_, attributes, _}, attributes_selectors) do
-     Enum.all? attributes_selectors, fn(attribute_selector) ->
-       AttributeSelector.match?(attributes, attribute_selector)
-     end
-   end
+  defp attributes_matches?(_node, []), do: true
+  defp attributes_matches?({_, [], _}, _), do: false
+  defp attributes_matches?({_, attributes, _}, attributes_selectors) do
+    Enum.all? attributes_selectors, fn(attribute_selector) ->
+      AttributeSelector.match?(attributes, attribute_selector)
+    end
+  end
 end

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -27,8 +27,12 @@ defmodule Floki.SelectorParser do
           {t, combinator} = consume_combinator(t, :descendant)
 
           %{selector | combinator: combinator}
-        {:greater,_} ->
+        {:greater, _} ->
           {t, combinator} = consume_combinator(t, :child)
+
+          %{selector | combinator: combinator}
+        {:plus, _} ->
+          {t, combinator} = consume_combinator(t, :sibling)
 
           %{selector | combinator: combinator}
         {:unknown, _, unknown} ->

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -329,6 +329,35 @@ defmodule FlokiTest do
     assert Floki.find(@html_with_img, "body > img") == []
   end
 
+  # Floki.find/2 - Sibling combinator
+
+  test "find sibling element" do
+    expected = [
+      {
+        "div", [{"class", "logo-container"}], [
+          {
+            "img", [
+              {"src", "http://twitter.com/logo.png"},
+              {"class", "img-without-closing-tag"}],
+            []
+          },
+          {
+            "img", [
+              {"src", "logo.png"},
+              {"id", "logo"}
+            ],
+            []
+          }
+        ]
+      }
+    ]
+
+    assert Floki.find(@html_with_img, "a + div") == expected
+    assert Floki.find(@html_with_img, "a + .logo-container") == expected
+    assert Floki.find(@html_with_img, "a + div #logo") == [{"img", [{"src", "logo.png"}, {"id", "logo"}], []}]
+    assert Floki.find(@html_with_img, "a + #logo") == []
+  end
+
   # Floki.find/2 - Using groups with comma
 
   test "get multiple elements using comma" do


### PR DESCRIPTION
With this feature, Floki is able to search sibling nodes, using the plus
combinator. Eg.: Floki.find(html, "h2 + a") => return anchors that are
siblings of "h2" nodes.

Specs: http://www.w3.org/TR/css3-selectors/#adjacent-sibling-combinators

Closes #16