### PR TITLE
Add general sibling combinator

### DIFF
--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -44,6 +44,10 @@ defmodule Floki.SelectorParser do
           {t, combinator} = consume_combinator(t, :sibling)
 
           %{selector | combinator: combinator}
+        {:tilde, _} ->
+          {t, combinator} = consume_combinator(t, :general_sibling)
+
+          %{selector | combinator: combinator}
         {:unknown, _, unknown} ->
           # TODO: find a better way to notify unknown tokens
           IO.puts("Unknown token #{inspect unknown}. Ignoring.")

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -21,6 +21,7 @@ Rules.
 {W}*,            : {token, {comma, TokenLine}}.
 {W}*>{W}*        : {token, {greater, TokenLine}}.
 {W}*\+{W}*       : {token, {plus, TokenLine}}.
+{W}*~{W}*        : {token, {tilde, TokenLine}}.
 {W}+             : {token, {space, TokenLine}}.
 .                : {token, {unknown, TokenLine, TokenChars}}.
 

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -358,6 +358,24 @@ defmodule FlokiTest do
     assert Floki.find(@html_with_img, "a + #logo") == []
   end
 
+  # Floki.find/2 - General sibling combinator
+
+  test "find general sibling elements" do
+    expected = [
+      {"a", [
+          {"href", "http://elixir-lang.org"},
+          {"class", "js-elixir js-cool"}],
+        ["Elixir lang"]},
+      {"a", [
+          {"href", "http://java.com"},
+          {"class", "js-java"}],
+        ["Java"]}
+    ]
+
+    assert Floki.find(@html, "a.js-google ~ a") == expected
+    assert Floki.find(@html, "a.js-java ~ a") == []
+  end
+
   # Floki.find/2 - Using groups with comma
 
   test "get multiple elements using comma" do


### PR DESCRIPTION
This feature enables searching for general siblings, like described in
the spec:
http://www.w3.org/TR/css3-selectors/#general-sibling-combinators

Closes #28