### PR TITLE
Add function to filter out tags and remove js from text function

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -237,4 +237,30 @@ defmodule Floki do
       attr_name == attribute_name
     end
   end
+
+  @doc """
+  Returns the nodes from a HTML tree that don't match the filter selector.
+
+  ## Examples
+
+      iex> Floki.filter_out("<div><script>hello</script> world</div>", "script")
+      {"div", [], [" world"]}
+
+      iex> Floki.filter_out([{"body", [], [{"script", [], []},{"div", [], []}]}], "script")
+      [{"body", [], [{"div", [], []}]}]
+
+  """
+
+  @spec filter_out(binary | html_tree, binary) :: list
+
+  def filter_out(html_tree, selector) when is_binary(html_tree) do
+    html_tree
+    |> parse
+    |> Floki.FilterOut.filter_out(selector)
+  end
+  def filter_out(elements, selector) do
+    Floki.FilterOut.filter_out(elements, selector)
+  end
+
+
 end

--- a/lib/floki/filter_out.ex
+++ b/lib/floki/filter_out.ex
@@ -21,12 +21,10 @@ defmodule Floki.FilterOut do
   end
 
   defp mapper(nodes, selector) when is_list(nodes) do
-    # IO.puts("mapping")
     Enum.filter_map(nodes, &filter(&1, selector), &mapper(&1, selector))
   end
 
   defp mapper({nodetext, x, y}, selector) do
-    # IO.puts("m: #{nodetext}")
     {nodetext, x, mapper(y, selector)}
   end
 

--- a/lib/floki/filter_out.ex
+++ b/lib/floki/filter_out.ex
@@ -1,0 +1,38 @@
+defmodule Floki.FilterOut do
+  @doc """
+  Helper functions for filtering out a specific element from the tree.
+  """
+
+  @type html_tree :: tuple | list
+  @type selector :: binary
+
+  @spec filter_out(html_tree, selector) :: tuple | list
+
+  def filter_out(html_tree, selector) do
+    mapper(html_tree, selector)
+  end
+
+  defp filter({nodetext, _, _}, selector) when nodetext === selector do
+    false
+  end
+
+  defp filter(_, _) do
+    true
+  end
+
+  defp mapper(nodes, selector) when is_list(nodes) do
+    # IO.puts("mapping")
+    Enum.filter_map(nodes, &filter(&1, selector), &mapper(&1, selector))
+  end
+
+  defp mapper({nodetext, x, y}, selector) do
+    # IO.puts("m: #{nodetext}")
+    {nodetext, x, mapper(y, selector)}
+  end
+
+  defp mapper(nodetext, _) do
+    nodetext
+  end
+
+
+end


### PR DESCRIPTION
First I added a function that filter out specific tags
Then I used this function to filter out script tags by default in the `text` function. I think that you generally do not want to get the js content of `<script>` when you use the function text.