### PR TITLE
For DeepText <br> nodes are replaced by newline (\n)

### DIFF
--- a/lib/floki/deep_text.ex
+++ b/lib/floki/deep_text.ex
@@ -29,6 +29,7 @@ defmodule Floki.DeepText do
     end
   end
   defp get_text({:comment, _}, acc), do: acc
+  defp get_text({"br", _, _}, acc), do: acc <> "\n"
   defp get_text({_, _, nodes}, acc) do
     get_text(nodes, acc)
   end

--- a/test/floki/deep_text_test.exs
+++ b/test/floki/deep_text_test.exs
@@ -27,4 +27,10 @@ defmodule Floki.DeepTextTest do
 
     assert Floki.DeepText.get(nodes) == "foobaz"
   end
+
+  test "text that includes a br node inside the tree" do
+    nodes = [{"a", [], ["foo"]}, {"br", [], []}, {"b", [], ["baz"]}]
+
+    assert Floki.DeepText.get(nodes) == "foo\nbaz"
+  end
 end


### PR DESCRIPTION
Not sure if this is in line with the design philosophy for Floki, but I thought for a DeepText text extraction, \<br> nodes should be changed into \n. The reason being that it retains the layout intent of the text itself and a \<br> node is a terminal node in that it can't have children or text (compared to a \<p>).

Furthermore, the \n can easily be replaced in the resulting plain text if you want the old result, whereas you can't insert a newline at this point. 

Please feel free to reject the pull request if you don't agree with the change and I can maintain a fork of the library for my own purposes.