### PR TITLE
Support rendering boolean attributes

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -106,6 +106,7 @@ defmodule Floki do
   end
 
   defp build_attrs({attr, value}, attrs), do: ~s(#{attrs} #{attr}="#{value}")
+  defp build_attrs(attr, attrs), do: "#{attrs} #{attr}"
 
   defp tag_for(type, attrs, _children) when type in @self_closing_tags do
     case attrs do

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -101,9 +101,11 @@ defmodule Floki do
 
   defp tag_attrs(attr_list) do
     attr_list
-    |> Enum.reduce("", fn({attr, value}, attrs) -> ~s(#{attrs} #{attr}="#{value}") end)
+    |> Enum.reduce("", &build_attrs/2)
     |> String.strip
   end
+
+  defp build_attrs({attr, value}, attrs), do: ~s(#{attrs} #{attr}="#{value}")
 
   defp tag_for(type, attrs, _children) when type in @self_closing_tags do
     case attrs do

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -154,6 +154,11 @@ defmodule FlokiTest do
     assert raw_html == ~s(<a href="uol.com.br" class="bar"><span>UOL</span><img src="foo.png"/></a>)
   end
 
+  test "raw_html (with boolean attribute)" do
+    raw_html = Floki.raw_html({"div", ["hidden"], []})
+    assert raw_html == "<div hidden></div>"
+  end
+
   # Floki.find/2 - Classes
 
   test "find elements with a given class" do


### PR DESCRIPTION
## Problem

The function `Floki.raw_html/1` does not handle boolean attributes.

A boolean attribute is one who's lack of corresponding value indicates truthiness. For example:
```html
<div hidden></div>
```

Since attributes in Floki's AST are represented as a 2 element tuple, there is no clear way to render an AST with boolean values.

## Solution

Update the rendering code to support rendering attributes that are not a 2 element tuple.

```elixir
Floki.raw_html({"div", ["hidden"], []})
"<div hidden></div>"
```

Thankfully this does not change any of the existing behavior in Floki, it just extends what is there to support another form of attribute when rendering an AST.

## A Note About Parsing

The above described AST, `{"div", ["hidden"], []}`, is not a valid AST produced by mochiweb_html (which is the parser used internally by Floki). In fact, mochiweb_html:parse/1 would produce something like:

```elixir
:mochiweb_html.parse("<div hidden></div>")
{"div", ["hidden", "hidden"], []}
```

After thinking about this (and trying and failing to "fix" mochiweb_html), I decided it might be OK to only produce a change in Floki (if only "for now"). This is based on the fact that mochiweb_html is an implementation detail. Producing HTML _from_ the AST is a different responsibility, which is in fact owned by the Floki lib.

What do you think?