### PR TITLE
Update docs with examples for html_tree type

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -135,6 +135,9 @@ defmodule Floki do
       iex> Floki.find("<p><a href='https://google.com'>Google</a></p>", "a")
       [{"a", [{"href", "https://google.com"}], ["Google"]}]
 
+      iex> Floki.find([{ "div", [], [{"a", [{ "href", "https://www.bing.com"}], ["Bing"]} ] }], "div a")
+      [{"a", [{"href", "https://www.bing.com"}], ["Bing"]}]
+
   """
 
   @spec find(binary | html_tree, binary) :: html_tree

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -135,8 +135,8 @@ defmodule Floki do
       iex> Floki.find("<p><a href='https://google.com'>Google</a></p>", "a")
       [{"a", [{"href", "https://google.com"}], ["Google"]}]
 
-      iex> Floki.find([{ "div", [], [{"a", [{ "href", "https://www.bing.com"}], ["Bing"]} ] }], "div a")
-      [{"a", [{"href", "https://www.bing.com"}], ["Bing"]}]
+      iex> Floki.find([{ "div", [], [{"a", [{"href", "https://google.com"}], ["Google"]}]}], "div a")
+      [{"a", [{"href", "https://google.com"}], ["Google"]}]
 
   """
 

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -173,6 +173,9 @@ defmodule Floki do
       iex> Floki.text("<ul><li>hello</li><li>world</li></ul>", sep: " ")
       "hello world"
 
+      iex> Floki.text([{"div", [], ["hello world"]}])
+      "hello world"
+
   """
 
   @spec text(html_tree | binary) :: binary
@@ -212,6 +215,9 @@ defmodule Floki do
       iex> Floki.attribute("<a href='https://google.com'>Google</a>", "a", "href")
       ["https://google.com"]
 
+      iex> Floki.attribute([{"a", [{"href", "https://google.com"}], ["Google"]}], "a", "href")
+      ["https://google.com"]
+
   """
 
   @spec attribute(binary | html_tree, binary, binary) :: list
@@ -228,6 +234,9 @@ defmodule Floki do
   ## Examples
 
       iex> Floki.attribute("<a href=https://google.com>Google</a>", "href")
+      ["https://google.com"]
+
+      iex> Floki.attribute([{"a", [{"href", "https://google.com"}], ["Google"]}], "href")
       ["https://google.com"]
 
   """


### PR DESCRIPTION
Adding example to depict explicit usage of tree in Floki.find/2