### PR TITLE
Re-word: array -> list

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -14,7 +14,7 @@ defmodule Floki.Finder do
   @doc """
   Find elements inside a HTML tree.
 
-  Second argument can be either a selector string, a selector struct or an array of selector structs.
+  Second argument can be either a selector string, a selector struct or a list of selector structs.
   """
 
   @spec find(html_tree, selector) :: html_tree

--- a/test/floki/deep_text_test.exs
+++ b/test/floki/deep_text_test.exs
@@ -15,7 +15,7 @@ defmodule Floki.DeepTextTest do
     assert Floki.DeepText.get(node, " ") == "Google"
   end
 
-  test "text from an array of deep nodes" do
+  test "text from a list of deep nodes" do
     nodes =
       [{"div", [],
           ["This is a text",
@@ -28,7 +28,7 @@ defmodule Floki.DeepTextTest do
      assert Floki.DeepText.get(nodes) == "This is a text that is divided into tiny pieces. It keeps growing... And ends."
   end
 
-  test "text from an array of deep nodes with a separator" do
+  test "text from a list of deep nodes with a separator" do
     nodes =
       [{"div", [],
           ["This is a text",

--- a/test/floki/flat_text_test.exs
+++ b/test/floki/flat_text_test.exs
@@ -39,7 +39,7 @@ defmodule Floki.FlatTextTest do
     assert Floki.FlatText.get(node, "|") == "The text start| and end."
   end
 
-  test "text from an array of nodes" do
+  test "text from a list of nodes" do
     nodes = [
             {"div",
               [],
@@ -59,7 +59,7 @@ defmodule Floki.FlatTextTest do
     assert Floki.FlatText.get(nodes) == expected_text
   end
 
-  test "text from an array of nodes with separator" do
+  test "text from a list of nodes with separator" do
     nodes = [
             {"div",
               [],


### PR DESCRIPTION
Noticed the mention of `array` in the docs. I think it makes sense to reword this everywhere.