### PR TITLE
Fix search of elements with namespace

### DIFF
--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -6,12 +6,12 @@ defmodule Floki.Selector do
   alias Floki.Selector
   alias Floki.AttributeSelector
 
-  defstruct id: nil, type: nil, classes: [], attributes: [], combinator: nil
+  defstruct id: nil, type: nil, classes: [], attributes: [], combinator: nil, namespace: nil
 
   @doc """
   Returns if a given node matches with a given selector.
   """
-  def match?(_node, %Selector{id: nil, type: nil, classes: [], attributes: []}) do
+  def match?(_node, %Selector{id: nil, type: nil, classes: [], attributes: [], namespace: nil}) do
     false
   end
   def match?(nil, _selector), do: false
@@ -19,6 +19,7 @@ defmodule Floki.Selector do
   def match?({:pi, _xml, _xml_attrs}, _selector), do: false
   def match?(html_node, selector) do
     id_match?(html_node, selector.id)
+      && namespace_match?(html_node, selector.namespace)
       && type_match?(html_node, selector.type)
       && classes_matches?(html_node, selector.classes)
       && attributes_matches?(html_node, selector.attributes)
@@ -35,9 +36,26 @@ defmodule Floki.Selector do
     end
   end
 
+  defp namespace_match?(_node, nil), do: true
+  defp namespace_match?(_node, "*"), do: true
+  defp namespace_match?({type_maybe_with_namespace, _, _}, namespace) do
+    case String.split(type_maybe_with_namespace, ":") do
+      [ns, _type] ->
+        ns == namespace
+      [_type] -> false
+    end
+  end
+
   defp type_match?(_node, nil), do: true
-  defp type_match?({type, _, _}, type), do: true
-  defp type_match?({_type, _, _}, "*"), do: true
+  defp type_match?(_node, "*"), do: true
+  defp type_match?({type_maybe_with_namespace, _, _}, type) do
+    case String.split(type_maybe_with_namespace, ":") do
+      [_ns, tp] ->
+        tp == type
+      [tp] ->
+        tp == type
+    end
+  end
   defp type_match?(_, _), do: false
 
   defp classes_matches?(_node, []), do: true

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -1,6 +1,6 @@
 Definitions.
 
-IDENTIFIER = [-A-Za-z0-9_:]+
+IDENTIFIER = [-A-Za-z0-9_]+
 QUOTED = (\".*\"|\'.*\')
 SYMBOL = [\[\]*]
 W = [\s\t\r\n\f]
@@ -22,6 +22,7 @@ Rules.
 {W}*>{W}*        : {token, {greater, TokenLine}}.
 {W}*\+{W}*       : {token, {plus, TokenLine}}.
 {W}*~{W}*        : {token, {tilde, TokenLine}}.
+{W}*\|{W}*       : {token, {namespace_pipe, TokenLine}}.
 {W}+             : {token, {space, TokenLine}}.
 .                : {token, {unknown, TokenLine, TokenChars}}.
 

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -78,4 +78,13 @@ defmodule Floki.SelectorParserTest do
       }
     }
   end
+
+  test "with namespace" do
+    tokens = tokenize("xyz | a")
+
+    assert SelectorParser.parse(tokens) == %Selector{
+      type: "a",
+      namespace: "xyz"
+    }
+  end
 end

--- a/test/floki/selector_tokenizer_test.exs
+++ b/test/floki/selector_tokenizer_test.exs
@@ -8,13 +8,15 @@ defmodule Floki.SelectorTokenizerTest do
 
   test "complex selector" do
     complex = """
-    a.link,
+    ns|a.link,
     .b[title=hello],
     [href~=foo] *,
     a > b
     """
 
     assert SelectorTokenizer.tokenize(complex) == [
+      {:identifier, 1, 'ns'},
+      {:namespace_pipe, 1},
       {:identifier, 1, 'a'},
       {:class, 1, 'link'},
       {:comma, 1},

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -451,10 +451,10 @@ defmodule FlokiTest do
   test "find elements inside namespaces" do
     xml = "<x:foo><x:bar>42</x:bar></x:foo>"
 
-    assert Floki.find(xml, "x:bar") == [{"x:bar", [], ["42"]}]
+    assert Floki.find(xml, "x | bar") == [{"x:bar", [], ["42"]}]
   end
 
-  @tag timeout: 1000
+  @tag timeout: 50
   test "find an inexistent element inside a invalid HTML" do
     assert Floki.find("something", "a") == []
     assert Floki.find("", "a") == []


### PR DESCRIPTION
It fixes a wrong selector when searcing elements using namespace, like
is described in https://www.w3.org/TR/css3-selectors/#univnmsp.

Now you can search for elements inside namespace with:

    Floki.find(html, "ns | tag")

This closes the issue #46 again.