### PR TITLE
Fix sibling after immediate children

### DIFF
--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -388,6 +388,30 @@ defmodule FlokiTest do
     assert Floki.find(html, "div > p > span > img") == expected
   end
 
+  test "find a sibling after immediate child chain" do
+    expected = [
+      {
+        "img", [
+          {"src", "http://twitter.com/logo.png"},
+          {"class", "img-without-closing-tag"}],
+        []
+      }
+    ]
+
+    html = ~s(
+    <div>
+      <p>
+        <span>
+          <img src="http://facebook.com/logo.png" />
+          <img src="http://twitter.com/logo.png" class="img-without-closing-tag" />
+        </span>
+      </p>
+    </div>
+    )
+
+    assert Floki.find(html, "div > p > span > img + img") == expected
+  end
+
   # Floki.find/2 - Sibling combinator
 
   test "find sibling element" do

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -456,6 +456,8 @@ defmodule FlokiTest do
     ]
 
     assert Floki.find(@html, "a.js-google ~ a") == expected
+    assert Floki.find(@html, "body > div > a.js-google ~ a") == expected
+    assert Floki.find(@html, "body > div ~ a") == []
     assert Floki.find(@html, "a.js-java ~ a") == []
   end
 


### PR DESCRIPTION
It fixes the search for sibling after a chain of immediate children.
The problem was in the siblings that were been passed to the traverse
child function. We had to fetch the siblings again after matching a
node.

Related to PR #57