### PR TITLE
Configure Logger format in config.exs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :logger, :console,
+  format: "$metadata $message\n",
+  metadata: [:module]

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -61,7 +61,7 @@ defmodule Floki.SelectorParser do
    do_parse(t, %{selector | combinator: combinator})
   end
   defp do_parse([{:unknown, _, unknown}|t], selector) do
-    Logger.warn("[floki] Unknown token #{inspect unknown}. Ignoring.")
+    Logger.warn("Unknown token #{inspect unknown}. Ignoring.")
 
     do_parse(t, selector)
   end
@@ -85,7 +85,7 @@ defmodule Floki.SelectorParser do
     consume_attribute(:done, t, attr_selector)
   end
   defp consume_attribute(:consuming, [unknown|t], attr_selector) do
-    Logger.warn("[floki] Unknown token #{inspect unknown}. Ignoring.")
+    Logger.warn("Unknown token #{inspect unknown}. Ignoring.")
     consume_attribute(:consuming, t, attr_selector)
   end
 

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -97,7 +97,7 @@ defmodule Floki.SelectorParserTest do
       end
     end
 
-    assert capture_log(log_capturer.("a { b")) =~ "[floki] Unknown token '{'. Ignoring."
-    assert capture_log(log_capturer.("a + b@")) =~ "[floki] Unknown token '@'. Ignoring."
+    assert capture_log(log_capturer.("a { b")) =~ "module=Floki.SelectorParser  Unknown token '{'. Ignoring."
+    assert capture_log(log_capturer.("a + b@")) =~ "module=Floki.SelectorParser  Unknown token '@'. Ignoring."
   end
 end


### PR DESCRIPTION
Using the Logger's own formatter to print module-specific metadata can make further Logger additions easier.