### PR TITLE
Remove support for Elixir 1.1 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ language: elixir
 matrix:
   include:
     - otp_release: 18.3
-      elixir: 1.1.1
-    - otp_release: 18.3
       elixir: 1.2.6
     - otp_release: 18.3
-      elixir: 1.3.2
+      elixir: 1.3.4
     - otp_release: 19.0
-      elixir: 1.3.2
+      elixir: 1.3.4
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Remove support for Elixir 1.1 and below
+
 ## [0.11.0] - 2016-10-12
 
 ### Added

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -1,7 +1,5 @@
 defmodule Floki do
-  alias Floki.Finder
-  alias Floki.Parser
-  alias Floki.FilterOut
+  alias Floki.{Finder, Parser, FilterOut}
 
   @moduledoc """
   Floki is a simple HTML parser that enables search for nodes using CSS selectors.

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -4,9 +4,7 @@ defmodule Floki.Finder do
   selectors.
   """
 
-  alias Floki.Selector
-  alias Floki.SelectorParser
-  alias Floki.SelectorTokenizer
+  alias Floki.{Selector, SelectorParser, SelectorTokenizer}
 
   @type html_tree :: tuple | list
   @type selector :: binary | %Selector{} | [%Selector{}]

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -3,8 +3,7 @@ defmodule Floki.Selector do
   Represents a CSS selector. It also have functions to match nodes with a given selector.
   """
 
-  alias Floki.Selector
-  alias Floki.AttributeSelector
+  alias Floki.{Selector, AttributeSelector}
 
   defstruct id: nil, type: nil, classes: [], attributes: [], combinator: nil, namespace: nil
 

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -5,9 +5,8 @@ defmodule Floki.SelectorParser do
   Parses a list of tokens returned from `SelectorTokenizer` and transfor into a `Selector`.
   """
 
-  alias Floki.Selector
-  alias Floki.AttributeSelector
-  alias Floki.Combinator
+  alias Floki.{Selector, AttributeSelector, Combinator}
+
   @attr_match_types [:equal, :dash_match, :includes, :prefix_match, :sufix_match, :substring_match]
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -9,9 +9,9 @@ defmodule Floki.Mixfile do
      name: "Floki",
      version: @version,
      description: @description,
-     elixir: ">= 1.1.0",
-     package: package,
-     deps: deps,
+     elixir: ">= 1.2.0",
+     package: package(),
+     deps: deps(),
      source_url: "https://github.com/philss/floki",
      docs: [extras: ["README.md"], main: "Floki"]]
   end

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -2,10 +2,7 @@ defmodule Floki.SelectorParserTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
 
-  alias Floki.Selector
-  alias Floki.Combinator
-  alias Floki.AttributeSelector
-  alias Floki.SelectorParser
+  alias Floki.{Selector, Combinator, AttributeSelector, SelectorParser}
 
   def tokenize(string) do
     Floki.SelectorTokenizer.tokenize(string)


### PR DESCRIPTION
Since the next versions will rely on `Map` with possible millions of keys, we should run only in versions equal or above 1.2.

This PR also improves the usage of aliases with the new syntax sugar provided in Elixir 1.2.