### PR TITLE
Refactor Floki.Finder to use HTML Tree for traverse and search

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -4,7 +4,9 @@ defmodule Floki.Finder do
   selectors.
   """
 
-  alias Floki.{Selector, SelectorParser, SelectorTokenizer}
+  alias Floki.{Combinator, Selector, SelectorParser, SelectorTokenizer}
+  alias Floki.{HTMLTree}
+  alias Floki.HTMLTree.Text
 
   @type html_tree :: tuple | list
   @type selector :: binary | %Selector{} | [%Selector{}]
@@ -17,6 +19,8 @@ defmodule Floki.Finder do
 
   @spec find(html_tree, selector) :: html_tree
 
+  def find(html_as_string, _) when is_binary(html_as_string), do: []
+  def find([], _), do: []
   def find(html_tree, selector_as_string) when is_binary(selector_as_string) do
     selectors = get_selectors(selector_as_string)
     find_selectors(html_tree, selectors)
@@ -38,13 +42,16 @@ defmodule Floki.Finder do
 
     {new_name, new_attrs, new_rest}
   end
-
   def apply_transformation(other, _transformation), do: other
 
-  defp find_selectors(html_tree, selectors) do
-    html_tree
-    |> traverse([], selectors, [])
+  defp find_selectors(html_tuple_or_list, selectors) do
+    tree = HTMLTree.build(html_tuple_or_list)
+
+    tree.node_ids
     |> Enum.reverse
+    |> get_nodes(tree)
+    |> Enum.flat_map(fn(html_node) -> get_matches_for_selectors(tree, html_node, selectors) end)
+    |> Enum.map(fn(html_node) -> as_tuple(tree, html_node) end)
   end
 
   defp get_selectors(selector_as_string) do
@@ -57,109 +64,122 @@ defmodule Floki.Finder do
     end)
   end
 
-  defp traverse(_, _, [], acc), do: acc
-  defp traverse({}, _, _, acc), do: acc
-  defp traverse([], _, _, acc), do: acc
-  defp traverse(string, _, _, acc) when is_binary(string), do: acc
-  defp traverse({:comment, _comment}, _, _, acc), do: acc
-  defp traverse({:pi, _xml, _xml_attrs}, _, _, acc), do: acc
-  defp traverse({:pi, _php_script}, _, _, acc), do: acc
-  defp traverse([html_node|sibling_nodes], _, selectors, acc) do
-    acc = traverse(html_node, sibling_nodes, selectors, acc)
-    traverse(sibling_nodes, [], selectors, acc)
+  defp get_matches_for_selectors(tree, html_node, selectors) do
+    selectors
+    |> Enum.flat_map(fn(selector) -> get_matches(tree, html_node, selector) end)
   end
-  defp traverse(html_node, sibling_nodes, [head_selector|tail_selectors], acc) do
-    acc = traverse(html_node, sibling_nodes, head_selector, acc)
-    traverse(html_node, sibling_nodes, tail_selectors, acc)
-  end
-  defp traverse({_, _, children_nodes} = html_node, sibling_nodes, selector, acc) do
+
+  defp get_matches(_tree, html_node, selector = %Selector{combinator: nil}) do
     if Selector.match?(html_node, selector) do
-      combinator = selector.combinator
-
-      case combinator do
-        nil ->
-          traverse(children_nodes, sibling_nodes, selector, [html_node|acc])
-        _ ->
-          traverse_using(combinator, children_nodes, sibling_nodes, acc)
-      end
+      [html_node]
     else
-      traverse(children_nodes, sibling_nodes, selector, acc)
+      []
     end
   end
-
-  defp traverse_using(combinator, children_nodes, sibling_nodes, acc) do
-    selector = combinator.selector
-
-    case combinator.match_type do
-      :descendant ->
-        traverse(children_nodes, [], selector, acc)
-      :child ->
-        traverse_child(children_nodes, selector, acc)
-      :sibling ->
-        traverse_sibling(sibling_nodes, selector, acc)
-      :general_sibling ->
-        traverse_general_sibling(sibling_nodes, selector, acc)
-      other ->
-        raise "Combinator of type \"#{other}\" not implemented"
-    end
-  end
-
-  defp traverse_child([], _selector, acc), do: acc
-  defp traverse_child([n|sibling_nodes], selector, acc) do
-    if Selector.match?(n, selector) do
-      combinator = selector.combinator
-
-      case combinator do
-        nil ->
-          traverse_child(sibling_nodes, selector, [n|acc])
-        _ ->
-          {_, _, children_nodes} = n
-          traverse_using(combinator, children_nodes, sibling_nodes, acc)
-      end
+  defp get_matches(tree, html_node, selector = %Selector{combinator: combinator}) do
+    if Selector.match?(html_node, selector) do
+      traverse_with(combinator, tree, [html_node])
     else
-      traverse_child(sibling_nodes, selector, acc)
+      []
     end
   end
 
-  defp traverse_sibling(sibling_nodes, selector, acc) do
-    sibling_nodes = Enum.drop_while(sibling_nodes, &ignore_node?/1)
+  # The stack serves as accumulator when there is another combinator to traverse.
+  # So the scope of one combinator is the stack (or acc) or the parent one.
+  defp traverse_with(_, _, []), do: []
+  defp traverse_with(nil, _, result), do: result
+  defp traverse_with(%Combinator{match_type: :child, selector: s}, tree, stack) do
+    results =
+      Enum.flat_map(stack, fn(html_node) ->
+        nodes = html_node.children_nodes_ids
+                |> Enum.reverse
+                |> get_nodes(tree)
 
-    sibling_node = case sibling_nodes do
-                     [] -> nil
-                     _  -> hd(sibling_nodes)
-                   end
+        Enum.filter(nodes, fn(html_node) -> Selector.match?(html_node, s) end)
+      end)
 
-    if Selector.match?(sibling_node, selector) do
-      case selector.combinator do
-        nil -> [sibling_node|acc]
-        _ ->
-          {_, _, children_nodes} = sibling_node
-          traverse(children_nodes, sibling_nodes, selector.combinator.selector, acc)
-      end
+    traverse_with(s.combinator, tree, results)
+  end
+  defp traverse_with(%Combinator{match_type: :sibling, selector: s}, tree, stack) do
+    results =
+      Enum.flat_map(stack, fn(html_node) ->
+        # It treats sibling as list to easily ignores those that didn't match
+        sibling_id = get_siblings(html_node, tree) |> Enum.take(1)
+
+        nodes = get_nodes(sibling_id, tree)
+
+        # Finally, try to match those siblings with the selector
+        Enum.filter(nodes, fn(html_node) -> Selector.match?(html_node, s) end)
+      end)
+
+    traverse_with(s.combinator, tree, results)
+  end
+  defp traverse_with(%Combinator{match_type: :general_sibling, selector: s}, tree, stack) do
+    results =
+      Enum.flat_map(stack, fn(html_node) ->
+        sibling_ids = get_siblings(html_node, tree)
+
+        nodes = get_nodes(sibling_ids, tree)
+
+        # Finally, try to match those siblings with the selector
+        Enum.filter(nodes, fn(html_node) -> Selector.match?(html_node, s) end)
+      end)
+
+    traverse_with(s.combinator, tree, results)
+  end
+  defp traverse_with(%Combinator{match_type: :descendant, selector: s}, tree, stack) do
+    results =
+      Enum.flat_map(stack, fn(html_node) ->
+        sibling_ids = get_siblings(html_node, tree)
+        ids_to_match = get_ids_for_decendant_match(html_node.node_id, sibling_ids, tree.node_ids)
+        nodes = ids_to_match
+                |> get_nodes(tree)
+
+        Enum.filter(nodes, fn(html_node) -> Selector.match?(html_node, s) end)
+      end)
+
+    traverse_with(s.combinator, tree, results)
+  end
+
+  defp get_nodes(ids, tree) do
+    Enum.map(ids, fn(id) -> Map.get(tree.nodes, id) end)
+  end
+
+  defp get_node(id, tree) do
+    Map.get(tree.nodes, id)
+  end
+
+  defp get_siblings(html_node, tree) do
+    parent = get_node(html_node.parent_node_id, tree)
+
+    if parent do
+      [_html_node_id | sibling_ids] = parent.children_nodes_ids
+                                      |> Enum.reverse
+                                      |> Enum.drop_while(fn(id) -> id != html_node.node_id end)
+      sibling_ids
     else
-      acc
+      []
     end
   end
 
-  defp traverse_general_sibling(sibling_nodes, selector, acc) do
-    sibling_nodes = Enum.drop_while(sibling_nodes, &ignore_node?/1)
+  # It takes all ids until the next sibling, that represents the ids under a given sub-tree
+  defp get_ids_for_decendant_match(node_id, sibling_ids, ids) do
+    [_ | ids_after] = ids
+                      |> Enum.reverse
+                      |> Enum.drop_while(fn(id) -> id != node_id end)
 
-    Enum.reduce(sibling_nodes, acc, fn(sibling_node, res_acc) ->
-      if Selector.match?(sibling_node, selector) do
-        case selector.combinator do
-          nil -> [sibling_node|res_acc]
-          _ ->
-            {_, _, children_nodes} = sibling_node
-            traverse(children_nodes, sibling_nodes, selector.combinator.selector, res_acc)
-        end
-      else
-        res_acc
-      end
-    end)
+    case sibling_ids do
+      [] -> ids_after
+      [sibling_id | _] -> Enum.take_while(ids_after, fn(id) -> id != sibling_id end)
+    end
   end
 
-  defp ignore_node?({:comment, _}), do: true
-  defp ignore_node?({:pi, _, _}), do: true
-  defp ignore_node?({:pi, _}), do: true
-  defp ignore_node?(_), do: false
+  def as_tuple(_tree, %Text{content: text}), do: text
+  def as_tuple(tree, html_node) do
+    children = html_node.children_nodes_ids
+               |> Enum.reverse
+               |> Enum.map(fn(id) -> as_tuple(tree, get_node(id, tree)) end)
+
+    {html_node.type, html_node.attributes, children}
+  end
 end

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -28,6 +28,7 @@ defmodule Floki.Finder do
     find_selectors(html_tree, [selector])
   end
 
+  # Not documented yet because it's an experimental API
   def apply_transformation({name, attrs, rest}, transformation) do
     {new_name, new_attrs} = transformation.({name, attrs})
 

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -1,0 +1,80 @@
+defmodule Floki.HTMLTree do
+  @moduledoc false
+
+  # Internal: Builds a `Map` representing a HTML tree based on tuples or list of tuples.
+  #
+  # It is useful because keeps references for each node, and the possibility to
+  # update the tree.
+
+  defstruct nodes: %{}, root_nodes_ids: [], node_ids: []
+
+  alias Floki.HTMLTree
+  alias Floki.HTMLTree.{HTMLNode, Text, IDSeeder}
+
+  def build({tag, attrs, children}) do
+    root_id = IDSeeder.seed([])
+
+    %HTMLTree{root_nodes_ids: [root_id],
+              node_ids: [root_id],
+              nodes: %{ root_id => %HTMLNode{type: tag, attributes: attrs, node_id: root_id} }}
+    |> build_tree(children, root_id, [])
+  end
+
+  def build(html_tuples) when is_list(html_tuples) do
+    reducer = fn
+      ({tag, attrs, children}, tree) ->
+        root_id = IDSeeder.seed(tree.node_ids)
+
+        root_node = %HTMLNode{type: tag, attributes: attrs, node_id: root_id}
+
+        %{tree | nodes: Map.put(tree.nodes, root_id, root_node),
+                 node_ids: [root_id | tree.node_ids],
+                 root_nodes_ids: [root_id | tree.root_nodes_ids]}
+        |> build_tree(children, root_id, [])
+      (_, tree) ->
+        tree
+    end
+
+    Enum.reduce(html_tuples, %HTMLTree{}, reducer)
+  end
+
+  defp build_tree(tree, [], _, []), do: tree
+  defp build_tree(tree, [{tag, attrs, child_children} | children], parent_id, stack) do
+    new_id = IDSeeder.seed(tree.node_ids)
+    new_node = %HTMLNode{type: tag,
+                         attributes: attrs,
+                         node_id: new_id,
+                         parent_node_id: parent_id}
+
+    nodes = put_new_node(tree.nodes, new_node)
+
+    %{tree | nodes: nodes, node_ids: [new_id | tree.node_ids]}
+    |> build_tree(child_children, new_id, [{parent_id, children} | stack])
+  end
+
+  defp build_tree(tree, [text | children], parent_id, stack) when is_binary(text) do
+    new_id = IDSeeder.seed(tree.node_ids)
+    new_node = %Text{content: text, node_id: new_id, parent_node_id: parent_id}
+
+    nodes = put_new_node(tree.nodes, new_node)
+
+    %{tree | nodes: nodes, node_ids: [new_id | tree.node_ids]}
+    |> build_tree(children, parent_id, stack)
+  end
+  defp build_tree(tree, [_other | children], parent_id, stack) do
+    build_tree(tree, children, parent_id, stack)
+  end
+  defp build_tree(tree, [], _, [{parent_node_id, children} | stack]) do
+    build_tree(tree, children, parent_node_id, stack)
+  end
+
+  defp put_new_node(nodes, new_node) do
+    parent_node = Map.get(nodes, new_node.parent_node_id)
+    children_ids = parent_node.children_nodes_ids
+    updated_parent = %{parent_node | children_nodes_ids: [new_node.node_id | children_ids]}
+
+    nodes
+    |> Map.put(new_node.node_id, new_node)
+    |> Map.put(new_node.parent_node_id, updated_parent)
+  end
+end

--- a/lib/floki/html_tree/html_node.ex
+++ b/lib/floki/html_tree/html_node.ex
@@ -1,0 +1,3 @@
+defmodule Floki.HTMLTree.HTMLNode do
+  defstruct type: "", attributes: [], children_nodes_ids: [], node_id: nil, parent_node_id: nil
+end

--- a/lib/floki/html_tree/id_seeder.ex
+++ b/lib/floki/html_tree/id_seeder.ex
@@ -1,0 +1,4 @@
+defmodule Floki.HTMLTree.IDSeeder do
+  def seed([]), do: 1
+  def seed([h | _]), do: h + 1
+end

--- a/lib/floki/html_tree/text.ex
+++ b/lib/floki/html_tree/text.ex
@@ -1,0 +1,3 @@
+defmodule Floki.HTMLTree.Text do
+  defstruct content: "", node_id: nil, parent_node_id: nil
+end

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -4,6 +4,7 @@ defmodule Floki.Selector do
   """
 
   alias Floki.{Selector, AttributeSelector}
+  alias Floki.HTMLTree.{HTMLNode, Text}
 
   defstruct id: nil, type: nil, classes: [], attributes: [], combinator: nil, namespace: nil
 
@@ -16,6 +17,10 @@ defmodule Floki.Selector do
   def match?(nil, _selector), do: false
   def match?({:comment, _comment}, _selector), do: false
   def match?({:pi, _xml, _xml_attrs}, _selector), do: false
+  def match?(%Text{}, _), do: false
+  def match?(%HTMLNode{type: type, attributes: attributes}, selector) do
+    Floki.Selector.match?({type, attributes, []}, selector)
+  end
   def match?(html_node, selector) do
     id_match?(html_node, selector.id)
       && namespace_match?(html_node, selector.namespace)

--- a/test/floki/deep_text_test.exs
+++ b/test/floki/deep_text_test.exs
@@ -1,5 +1,5 @@
 defmodule Floki.DeepTextTest do
-  use ExUnit.Case, assync: true
+  use ExUnit.Case, async: true
 
   doctest Floki.DeepText
 

--- a/test/floki/html_tree_test.exs
+++ b/test/floki/html_tree_test.exs
@@ -1,0 +1,79 @@
+defmodule Floki.HTMLTreeTest do
+  use ExUnit.Case, async: true
+
+  alias Floki.HTMLTree
+  alias Floki.HTMLTree.{HTMLNode, Text}
+
+  test "build the tuple tree into html tree" do
+    link_attrs = [{"href", "/home"}]
+    html_tuple =
+      {"html", [],
+       [
+         {:comment, "start of the stack"},
+         {"a", link_attrs,
+          [{"b", [], ["click me"]}]},
+         {"span", [], []}]}
+
+    assert HTMLTree.build(html_tuple) == %HTMLTree{
+     root_nodes_ids: [1],
+     node_ids: [5, 4, 3, 2, 1],
+     nodes: %{
+       1 => %HTMLNode{type: "html",
+                      children_nodes_ids: [5, 2],
+                      node_id: 1},
+       2 => %HTMLNode{type: "a",
+                      attributes: link_attrs,
+                      parent_node_id: 1,
+                      children_nodes_ids: [3],
+                      node_id: 2},
+       3 => %HTMLNode{type: "b",
+                      parent_node_id: 2,
+                      children_nodes_ids: [4],
+                      node_id: 3},
+       4 => %Text{content: "click me",
+                  parent_node_id: 3,
+                  node_id: 4},
+       5 => %HTMLNode{type: "span",
+                      parent_node_id: 1,
+                      node_id: 5}
+     }
+    }
+  end
+
+  test "build HTML tuple list" do
+    link_attrs = [{"href", "/home"}]
+    html_tuple_list = [
+      {"html", [],
+       [
+         {:comment, "start of the stack"},
+         {"a", link_attrs,
+          [{"b", [], ["click me"]}]},
+         {"span", [], []}]}
+    ]
+
+    assert HTMLTree.build(html_tuple_list) == %HTMLTree{
+     root_nodes_ids: [1],
+     node_ids: [5, 4, 3, 2, 1],
+     nodes: %{
+       1 => %HTMLNode{type: "html",
+                      children_nodes_ids: [5, 2],
+                      node_id: 1},
+       2 => %HTMLNode{type: "a",
+                     attributes: link_attrs,
+                     parent_node_id: 1,
+                     children_nodes_ids: [3],
+                     node_id: 2},
+       3 => %HTMLNode{type: "b",
+                      parent_node_id: 2,
+                      children_nodes_ids: [4],
+                      node_id: 3},
+       4 => %Text{content: "click me",
+                  parent_node_id: 3,
+                  node_id: 4},
+       5 => %HTMLNode{type: "span",
+                      parent_node_id: 1,
+                      node_id: 5}
+     }
+    }
+  end
+end

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -1,5 +1,5 @@
 defmodule Floki.SelectorParserTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import ExUnit.CaptureLog
 
   alias Floki.{Selector, Combinator, AttributeSelector, SelectorParser}

--- a/test/floki/selector_tokenizer_test.exs
+++ b/test/floki/selector_tokenizer_test.exs
@@ -1,5 +1,5 @@
 defmodule Floki.SelectorTokenizerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Floki.SelectorTokenizer
 
   test "empty selector" do


### PR DESCRIPTION
This is needed in order to be the base of the next features such as: update tree, find nodes using the "pseudo class" :nth-child, filter out elements with selectors, and more.

With this refactor it is now easier to analyse the position and to get nodes that are related to a given node.

It closes issue #71.