### PR TITLE
Add support for nth-child pseudo-class selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Floki.find(html, ".headline")
 # => "Floki"
 ```
 
+## References
+
+- https://www.w3.org/community/webed/wiki/CSS/Selectors
+
 ## License
 
 Floki is under MIT license. Check the `LICENSE` file for more details.

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -6,8 +6,9 @@ defmodule Floki.Finder do
   selectors.
   """
 
-  alias Floki.{Combinator, Selector, SelectorParser, SelectorTokenizer, PseudoClass}
-  alias Floki.{HTMLTree}
+  alias Floki.{Combinator, Selector, SelectorParser, SelectorTokenizer}
+  alias Floki.HTMLTree
+  alias Floki.Selector.PseudoClass
   alias Floki.HTMLTree.Text
 
   @type html_tree :: tuple | list

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -174,8 +174,8 @@ defmodule Floki.Finder do
     end
   end
 
-  def as_tuple(_tree, %Text{content: text}), do: text
-  def as_tuple(tree, html_node) do
+  defp as_tuple(_tree, %Text{content: text}), do: text
+  defp as_tuple(tree, html_node) do
     children = html_node.children_nodes_ids
                |> Enum.reverse
                |> Enum.map(fn(id) -> as_tuple(tree, get_node(id, tree)) end)

--- a/lib/floki/pseudo_class.ex
+++ b/lib/floki/pseudo_class.ex
@@ -1,4 +1,6 @@
 defmodule Floki.PseudoClass do
+  @moduledoc false
+
   require Logger
 
   defstruct name: "", value: nil

--- a/lib/floki/pseudo_class.ex
+++ b/lib/floki/pseudo_class.ex
@@ -1,0 +1,6 @@
+defmodule Floki.PseudoClass do
+  defstruct name: "", value: nil
+  """
+  Represents a pseudo-class selector
+  """
+end

--- a/lib/floki/pseudo_class.ex
+++ b/lib/floki/pseudo_class.ex
@@ -3,11 +3,10 @@ defmodule Floki.PseudoClass do
 
   require Logger
 
+  # Represents a pseudo-class selector
   defstruct name: "", value: nil
 
   alias Floki.HTMLTree.HTMLNode
-
-  # Represents a pseudo-class selector
 
   def match_nth_child?(_, %HTMLNode{parent_node_id: nil}, _), do: false
   def match_nth_child?(tree, html_node, %__MODULE__{value: position}) when is_integer(position) do

--- a/lib/floki/pseudo_class.ex
+++ b/lib/floki/pseudo_class.ex
@@ -1,6 +1,37 @@
 defmodule Floki.PseudoClass do
+  require Logger
+
   defstruct name: "", value: nil
-  """
-  Represents a pseudo-class selector
-  """
+
+  alias Floki.HTMLTree.HTMLNode
+
+  # Represents a pseudo-class selector
+
+  def match_nth_child?(_, %HTMLNode{parent_node_id: nil}, _), do: false
+  def match_nth_child?(tree, html_node, %__MODULE__{value: position}) when is_integer(position) do
+    node_position(tree, html_node) == position
+  end
+  def match_nth_child?(tree, html_node, %__MODULE__{value: "even"}) do
+    position = node_position(tree, html_node)
+    rem(position, 2) == 0
+  end
+  def match_nth_child?(tree, html_node, %__MODULE__{value: "odd"}) do
+    position = node_position(tree, html_node)
+    rem(position, 2) == 1
+  end
+  def match_nth_child?(_, _, %__MODULE__{value: expression}) do
+    Logger.warn("Pseudo-class nth-child with expressions like #{inspect expression} are not supported yet. Ignoring.")
+    false
+  end
+
+  defp node_position(tree, html_node) do
+    parent_node = Map.get(tree.nodes, html_node.parent_node_id)
+    children_nodes_ids = parent_node.children_nodes_ids
+                         |> Enum.reverse
+                         |> Enum.with_index(1)
+
+    {_node_id, position} = Enum.find(children_nodes_ids, fn({id, _}) -> id == html_node.node_id end)
+
+    position
+  end
 end

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -6,7 +6,13 @@ defmodule Floki.Selector do
   alias Floki.{Selector, AttributeSelector}
   alias Floki.HTMLTree.{HTMLNode, Text}
 
-  defstruct id: nil, type: nil, classes: [], attributes: [], combinator: nil, namespace: nil
+  defstruct id: nil,
+            type: nil,
+            classes: [],
+            attributes: [],
+            namespace: nil,
+            pseudo_class: nil,
+            combinator: nil
 
   @doc """
   Returns if a given node matches with a given selector.

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -1,4 +1,4 @@
-defmodule Floki.PseudoClass do
+defmodule Floki.Selector.PseudoClass do
   @moduledoc false
 
   require Logger

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -46,6 +46,18 @@ defmodule Floki.SelectorParser do
     pseudo_class = selector.pseudo_class
     do_parse(t, %{selector | pseudo_class: %{pseudo_class | value: pseudo_class_int}})
   end
+  defp do_parse([{:pseudo_class_even, _} | t], selector) do
+    pseudo_class = selector.pseudo_class
+    do_parse(t, %{selector | pseudo_class: %{pseudo_class | value: "even"}})
+  end
+  defp do_parse([{:pseudo_class_odd, _} | t], selector) do
+    pseudo_class = selector.pseudo_class
+    do_parse(t, %{selector | pseudo_class: %{pseudo_class | value: "odd"}})
+  end
+  defp do_parse([{:pseudo_class_pattern, _, pattern} | t], selector) do
+    pseudo_class = selector.pseudo_class
+    do_parse(t, %{selector | pseudo_class: %{pseudo_class | value: to_string(pattern)}})
+  end
   defp do_parse([{:space, _} | t], selector) do
     {t, combinator} = consume_combinator(t, :descendant)
 

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -5,7 +5,7 @@ defmodule Floki.SelectorParser do
   Parses a list of tokens returned from `SelectorTokenizer` and transfor into a `Selector`.
   """
 
-  alias Floki.{Selector, AttributeSelector, Combinator}
+  alias Floki.{Selector, AttributeSelector, Combinator, PseudoClass}
 
   @attr_match_types [:equal, :dash_match, :includes, :prefix_match, :sufix_match, :substring_match]
 
@@ -19,47 +19,54 @@ defmodule Floki.SelectorParser do
   end
 
   defp do_parse([], selector), do: selector
-  defp do_parse([{:identifier, _, namespace}, {:namespace_pipe, _}|t], selector) do
+  defp do_parse([{:identifier, _, namespace}, {:namespace_pipe, _} | t], selector) do
     do_parse(t, %{selector | namespace: to_string(namespace)})
   end
-  defp do_parse([{:identifier, _, type}|t], selector) do
+  defp do_parse([{:identifier, _, type} | t], selector) do
     do_parse(t, %{selector | type: to_string(type)})
   end
-  defp do_parse([{'*', _}|t], selector) do
+  defp do_parse([{'*', _} | t], selector) do
     do_parse(t, %{selector | type: "*"})
   end
-  defp do_parse([{:hash, _, id}|t], selector) do
+  defp do_parse([{:hash, _, id} | t], selector) do
     do_parse(t, %{selector | id: to_string(id)})
   end
-  defp do_parse([{:class, _, class}|t], selector) do
-    do_parse(t, %{selector | classes: [to_string(class)|selector.classes]})
+  defp do_parse([{:class, _, class} | t], selector) do
+    do_parse(t, %{selector | classes: [to_string(class) | selector.classes]})
   end
-  defp do_parse([{'[', _}|t], selector) do
-      {t, result} = consume_attribute(t)
+  defp do_parse([{'[', _} | t], selector) do
+    {t, result} = consume_attribute(t)
 
-      do_parse(t, %{selector | attributes: [result|selector.attributes]})
+    do_parse(t, %{selector | attributes: [result | selector.attributes]})
   end
-  defp do_parse([{:space, _}|t], selector) do
+  defp do_parse([{:pseudo, _, pseudo_class} | t], selector) do
+    do_parse(t, %{selector | pseudo_class: %PseudoClass{name: to_string(pseudo_class)}})
+  end
+  defp do_parse([{:pseudo_class_int, _, pseudo_class_int} | t], selector) do
+    pseudo_class = selector.pseudo_class
+    do_parse(t, %{selector | pseudo_class: %{pseudo_class | value: pseudo_class_int}})
+  end
+  defp do_parse([{:space, _} | t], selector) do
     {t, combinator} = consume_combinator(t, :descendant)
 
     do_parse(t, %{selector | combinator: combinator})
   end
-  defp do_parse([{:greater, _}|t], selector) do
+  defp do_parse([{:greater, _} | t], selector) do
     {t, combinator} = consume_combinator(t, :child)
 
     do_parse(t, %{selector | combinator: combinator})
   end
-  defp do_parse([{:plus, _}|t], selector) do
+  defp do_parse([{:plus, _} | t], selector) do
     {t, combinator} = consume_combinator(t, :sibling)
 
     do_parse(t, %{selector | combinator: combinator})
   end
-  defp do_parse([{:tilde, _}|t], selector) do
+  defp do_parse([{:tilde, _} | t], selector) do
     {t, combinator} = consume_combinator(t, :general_sibling)
 
-   do_parse(t, %{selector | combinator: combinator})
+    do_parse(t, %{selector | combinator: combinator})
   end
-  defp do_parse([{:unknown, _, unknown}|t], selector) do
+  defp do_parse([{:unknown, _, unknown} | t], selector) do
     Logger.warn("Unknown token #{inspect unknown}. Ignoring.")
 
     do_parse(t, selector)
@@ -68,22 +75,22 @@ defmodule Floki.SelectorParser do
   defp consume_attribute(tokens), do: consume_attribute(:consuming, tokens, %AttributeSelector{})
   defp consume_attribute(_, [], attr_selector), do: {[], attr_selector}
   defp consume_attribute(:done, tokens, attr_selector), do: {tokens, attr_selector}
-  defp consume_attribute(:consuming, [{:identifier, _, identifier}|t], attr_selector) do
+  defp consume_attribute(:consuming, [{:identifier, _, identifier} | t], attr_selector) do
     new_selector = set_attribute_name_or_value(attr_selector, identifier)
     consume_attribute(:consuming, t, new_selector)
   end
-  defp consume_attribute(:consuming, [{match_type, _}|t], attr_selector) when match_type in @attr_match_types do
+  defp consume_attribute(:consuming, [{match_type, _} | t], attr_selector) when match_type in @attr_match_types do
     new_selector = %{attr_selector | match_type: match_type}
     consume_attribute(:consuming, t, new_selector)
   end
-  defp consume_attribute(:consuming, [{:quoted, _, value}|t], attr_selector) do
+  defp consume_attribute(:consuming, [{:quoted, _, value} | t], attr_selector) do
     new_selector = %{attr_selector | value: to_string(value)}
     consume_attribute(:consuming, t, new_selector)
   end
-  defp consume_attribute(:consuming, [{']', _}|t], attr_selector) do
+  defp consume_attribute(:consuming, [{']', _} | t], attr_selector) do
     consume_attribute(:done, t, attr_selector)
   end
-  defp consume_attribute(:consuming, [unknown|t], attr_selector) do
+  defp consume_attribute(:consuming, [unknown | t], attr_selector) do
     Logger.warn("Unknown token #{inspect unknown}. Ignoring.")
     consume_attribute(:consuming, t, attr_selector)
   end

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -5,7 +5,8 @@ defmodule Floki.SelectorParser do
   Parses a list of tokens returned from `SelectorTokenizer` and transfor into a `Selector`.
   """
 
-  alias Floki.{Selector, AttributeSelector, Combinator, PseudoClass}
+  alias Floki.{Selector, AttributeSelector, Combinator}
+  alias Floki.Selector.PseudoClass
 
   @attr_match_types [:equal, :dash_match, :includes, :prefix_match, :sufix_match, :substring_match]
 

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -2,16 +2,25 @@ Definitions.
 
 IDENTIFIER = [-A-Za-z0-9_]+
 QUOTED = (\"[^"]*\"|\'[^']*\')
+INT = [0-9]+
+ODD = (o|O)(d|D)(d|D)
+EVEN = (e|E)(v|V)(e|E)(n|N)
+PSEUDO_EXP = (\+|-)?({INT})?(n|N)((\+|-){INT})?
 SYMBOL = [\[\]*]
 W = [\s\t\r\n\f]
 
 Rules.
 
 {IDENTIFIER}     : {token, {identifier, TokenLine, TokenChars}}.
-{QUOTED}         : {token, {quoted, TokenLine, remove_quotes(TokenChars)}}.
+{QUOTED}         : {token, {quoted, TokenLine, remove_wrapper(TokenChars)}}.
 {SYMBOL}         : {token, {TokenChars, TokenLine}}.
 #{IDENTIFIER}    : {token, {hash, TokenLine, tail(TokenChars)}}.
 \.{IDENTIFIER}   : {token, {class, TokenLine, tail(TokenChars)}}.
+\:{IDENTIFIER}   : {token, {pseudo, TokenLine, tail(TokenChars)}}.
+\({INT}\)        : {token, {pseudo_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
+\({ODD}\)        : {token, {pseudo_odd, TokenLine}}.
+\({EVEN}\)       : {token, {pseudo_even, TokenLine}}.
+\({PSEUDO_EXP}\) : {token, {pseudo_exp, TokenLine, remove_wrapper(TokenChars)}}.
 ~=               : {token, {includes, TokenLine}}.
 \|=              : {token, {dash_match, TokenLine}}.
 \^=              : {token, {prefix_match, TokenLine}}.
@@ -29,7 +38,7 @@ Rules.
 
 Erlang code.
 
-remove_quotes(Chars) ->
+remove_wrapper(Chars) ->
   Len = string:len(Chars),
   string:substr(Chars, 2, Len - 2).
 

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -5,35 +5,35 @@ QUOTED = (\"[^"]*\"|\'[^']*\')
 INT = [0-9]+
 ODD = (o|O)(d|D)(d|D)
 EVEN = (e|E)(v|V)(e|E)(n|N)
-PSEUDO_EXP = (\+|-)?({INT})?(n|N)((\+|-){INT})?
+PSEUDO_PATT = (\+|-)?({INT})?(n|N)((\+|-){INT})?
 SYMBOL = [\[\]*]
 W = [\s\t\r\n\f]
 
 Rules.
 
-{IDENTIFIER}     : {token, {identifier, TokenLine, TokenChars}}.
-{QUOTED}         : {token, {quoted, TokenLine, remove_wrapper(TokenChars)}}.
-{SYMBOL}         : {token, {TokenChars, TokenLine}}.
-#{IDENTIFIER}    : {token, {hash, TokenLine, tail(TokenChars)}}.
-\.{IDENTIFIER}   : {token, {class, TokenLine, tail(TokenChars)}}.
-\:{IDENTIFIER}   : {token, {pseudo, TokenLine, tail(TokenChars)}}.
-\({INT}\)        : {token, {pseudo_class_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
-\({ODD}\)        : {token, {pseudo_class_odd, TokenLine}}.
-\({EVEN}\)       : {token, {pseudo_class_even, TokenLine}}.
-\({PSEUDO_EXP}\) : {token, {pseudo_class_exp, TokenLine, remove_wrapper(TokenChars)}}.
-~=               : {token, {includes, TokenLine}}.
-\|=              : {token, {dash_match, TokenLine}}.
-\^=              : {token, {prefix_match, TokenLine}}.
-\$=              : {token, {sufix_match, TokenLine}}.
-\*=              : {token, {substring_match, TokenLine}}.
-=                : {token, {equal, TokenLine}}.
-{W}*,            : {token, {comma, TokenLine}}.
-{W}*>{W}*        : {token, {greater, TokenLine}}.
-{W}*\+{W}*       : {token, {plus, TokenLine}}.
-{W}*~{W}*        : {token, {tilde, TokenLine}}.
-{W}*\|{W}*       : {token, {namespace_pipe, TokenLine}}.
-{W}+             : {token, {space, TokenLine}}.
-.                : {token, {unknown, TokenLine, TokenChars}}.
+{IDENTIFIER}                         : {token, {identifier, TokenLine, TokenChars}}.
+{QUOTED}                             : {token, {quoted, TokenLine, remove_wrapper(TokenChars)}}.
+{SYMBOL}                             : {token, {TokenChars, TokenLine}}.
+#{IDENTIFIER}                        : {token, {hash, TokenLine, tail(TokenChars)}}.
+\.{IDENTIFIER}                       : {token, {class, TokenLine, tail(TokenChars)}}.
+\:{IDENTIFIER}                       : {token, {pseudo, TokenLine, tail(TokenChars)}}.
+\({INT}\)                            : {token, {pseudo_class_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
+\({ODD}\)                            : {token, {pseudo_class_odd, TokenLine}}.
+\({EVEN}\)                           : {token, {pseudo_class_even, TokenLine}}.
+\({PSEUDO_PATT}\)                    : {token, {pseudo_class_pattern, TokenLine, remove_wrapper(TokenChars)}}.
+~=                                   : {token, {includes, TokenLine}}.
+\|=                                  : {token, {dash_match, TokenLine}}.
+\^=                                  : {token, {prefix_match, TokenLine}}.
+\$=                                  : {token, {sufix_match, TokenLine}}.
+\*=                                  : {token, {substring_match, TokenLine}}.
+=                                    : {token, {equal, TokenLine}}.
+{W}*,                                : {token, {comma, TokenLine}}.
+{W}*>{W}*                            : {token, {greater, TokenLine}}.
+{W}*\+{W}*                           : {token, {plus, TokenLine}}.
+{W}*~{W}*                            : {token, {tilde, TokenLine}}.
+{W}*\|{W}*                           : {token, {namespace_pipe, TokenLine}}.
+{W}+                                 : {token, {space, TokenLine}}.
+.                                    : {token, {unknown, TokenLine, TokenChars}}.
 
 
 Erlang code.

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -17,10 +17,10 @@ Rules.
 #{IDENTIFIER}    : {token, {hash, TokenLine, tail(TokenChars)}}.
 \.{IDENTIFIER}   : {token, {class, TokenLine, tail(TokenChars)}}.
 \:{IDENTIFIER}   : {token, {pseudo, TokenLine, tail(TokenChars)}}.
-\({INT}\)        : {token, {pseudo_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
-\({ODD}\)        : {token, {pseudo_odd, TokenLine}}.
-\({EVEN}\)       : {token, {pseudo_even, TokenLine}}.
-\({PSEUDO_EXP}\) : {token, {pseudo_exp, TokenLine, remove_wrapper(TokenChars)}}.
+\({INT}\)        : {token, {pseudo_class_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
+\({ODD}\)        : {token, {pseudo_class_odd, TokenLine}}.
+\({EVEN}\)       : {token, {pseudo_class_even, TokenLine}}.
+\({PSEUDO_EXP}\) : {token, {pseudo_class_exp, TokenLine, remove_wrapper(TokenChars)}}.
 ~=               : {token, {includes, TokenLine}}.
 \|=              : {token, {dash_match, TokenLine}}.
 \^=              : {token, {prefix_match, TokenLine}}.

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -2,7 +2,8 @@ defmodule Floki.SelectorParserTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureLog
 
-  alias Floki.{Selector, Combinator, PseudoClass, AttributeSelector, SelectorParser}
+  alias Floki.{Selector, Combinator, AttributeSelector, SelectorParser}
+  alias Floki.Selector.PseudoClass
 
   def tokenize(string) do
     Floki.SelectorTokenizer.tokenize(string)

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -2,7 +2,7 @@ defmodule Floki.SelectorParserTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureLog
 
-  alias Floki.{Selector, Combinator, AttributeSelector, SelectorParser}
+  alias Floki.{Selector, Combinator, PseudoClass, AttributeSelector, SelectorParser}
 
   def tokenize(string) do
     Floki.SelectorTokenizer.tokenize(string)
@@ -84,6 +84,15 @@ defmodule Floki.SelectorParserTest do
       type: "a",
       namespace: "xyz"
     }
+  end
+
+  test "with pseudo-class" do
+    tokens = tokenize("li:nth-child(2)")
+
+    assert SelectorParser.parse(tokens) == %Selector{
+     type: "li",
+     pseudo_class: %PseudoClass{name: "nth-child", value: 2},
+   }
   end
 
   test "warn unknown tokens" do

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -90,9 +90,30 @@ defmodule Floki.SelectorParserTest do
     tokens = tokenize("li:nth-child(2)")
 
     assert SelectorParser.parse(tokens) == %Selector{
-     type: "li",
-     pseudo_class: %PseudoClass{name: "nth-child", value: 2},
-   }
+      type: "li",
+      pseudo_class: %PseudoClass{name: "nth-child", value: 2},
+    }
+
+    tokens = tokenize("tr:nth-child(odd)")
+
+    assert SelectorParser.parse(tokens) == %Selector{
+      type: "tr",
+      pseudo_class: %PseudoClass{name: "nth-child", value: "odd"}
+    }
+
+    tokens = tokenize("td:nth-child(even)")
+
+    assert SelectorParser.parse(tokens) == %Selector{
+      type: "td",
+      pseudo_class: %PseudoClass{name: "nth-child", value: "even"}
+    }
+
+    tokens = tokenize("div:nth-child(-n+3)")
+
+    assert SelectorParser.parse(tokens) == %Selector{
+      type: "div",
+      pseudo_class: %PseudoClass{name: "nth-child", value: "-n+3"}
+    }
   end
 
   test "warn unknown tokens" do

--- a/test/floki/selector_tokenizer_test.exs
+++ b/test/floki/selector_tokenizer_test.exs
@@ -60,4 +60,41 @@ defmodule Floki.SelectorTokenizerTest do
       {:unknown, 1, '&'}
     ]
   end
+
+  test "pseudo classes" do
+    assert SelectorTokenizer.tokenize(":nth-child(3)") == [
+      {:pseudo, 1, 'nth-child'},
+      {:pseudo_int, 1, 3}
+    ]
+
+    assert SelectorTokenizer.tokenize(":nth-child(odd)") == [
+      {:pseudo, 1, 'nth-child'},
+      {:pseudo_odd, 1}
+    ]
+
+    assert SelectorTokenizer.tokenize(":nth-child(even)") == [
+      {:pseudo, 1, 'nth-child'},
+      {:pseudo_even, 1}
+    ]
+
+    assert SelectorTokenizer.tokenize(":nth-child(2n+1)") == [
+      {:pseudo, 1, 'nth-child'},
+      {:pseudo_exp, 1, '2n+1'}
+    ]
+
+    assert SelectorTokenizer.tokenize(":nth-child(2n-1)") == [
+      {:pseudo, 1, 'nth-child'},
+      {:pseudo_exp, 1, '2n-1'}
+    ]
+
+    assert SelectorTokenizer.tokenize(":nth-child(n+0)") == [
+      {:pseudo, 1, 'nth-child'},
+      {:pseudo_exp, 1, 'n+0'}
+    ]
+
+    assert SelectorTokenizer.tokenize(":nth-child(-n+6)") == [
+      {:pseudo, 1, 'nth-child'},
+      {:pseudo_exp, 1, '-n+6'}
+    ]
+  end
 end

--- a/test/floki/selector_tokenizer_test.exs
+++ b/test/floki/selector_tokenizer_test.exs
@@ -79,22 +79,22 @@ defmodule Floki.SelectorTokenizerTest do
 
     assert SelectorTokenizer.tokenize(":nth-child(2n+1)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_class_exp, 1, '2n+1'}
+      {:pseudo_class_pattern, 1, '2n+1'}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(2n-1)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_class_exp, 1, '2n-1'}
+      {:pseudo_class_pattern, 1, '2n-1'}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(n+0)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_class_exp, 1, 'n+0'}
+      {:pseudo_class_pattern, 1, 'n+0'}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(-n+6)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_class_exp, 1, '-n+6'}
+      {:pseudo_class_pattern, 1, '-n+6'}
     ]
   end
 end

--- a/test/floki/selector_tokenizer_test.exs
+++ b/test/floki/selector_tokenizer_test.exs
@@ -64,37 +64,37 @@ defmodule Floki.SelectorTokenizerTest do
   test "pseudo classes" do
     assert SelectorTokenizer.tokenize(":nth-child(3)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_int, 1, 3}
+      {:pseudo_class_int, 1, 3}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(odd)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_odd, 1}
+      {:pseudo_class_odd, 1}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(even)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_even, 1}
+      {:pseudo_class_even, 1}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(2n+1)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_exp, 1, '2n+1'}
+      {:pseudo_class_exp, 1, '2n+1'}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(2n-1)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_exp, 1, '2n-1'}
+      {:pseudo_class_exp, 1, '2n-1'}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(n+0)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_exp, 1, 'n+0'}
+      {:pseudo_class_exp, 1, 'n+0'}
     ]
 
     assert SelectorTokenizer.tokenize(":nth-child(-n+6)") == [
       {:pseudo, 1, 'nth-child'},
-      {:pseudo_exp, 1, '-n+6'}
+      {:pseudo_class_exp, 1, '-n+6'}
     ]
   end
 end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -482,6 +482,40 @@ defmodule FlokiTest do
     assert Floki.find(@html_with_img, ".js-x-logo, #logo") == expected
   end
 
+  # Floki.find/2 - Pseudo-class
+
+  test "get elements by nth-child and first-child pseudo-classes" do
+    html = """
+    <html>
+    <body>
+      <a href="/a">1</a>
+      <a href="/b">2</a>
+      <a href="/c">3</a>
+      <a href="/d">4</a>
+      <a href="/e">5</a>
+    </html>
+    """
+
+    assert Floki.find(html, "a:nth-child(2)") == [
+      {"a", [{"href", "/b"}], ["2"] }
+    ]
+
+    assert Floki.find(html, "a:nth-child(even)") == [
+      {"a", [{"href", "/b"}], ["2"] },
+      {"a", [{"href", "/d"}], ["4"] }
+    ]
+
+    assert Floki.find(html, "a:nth-child(odd)") == [
+      {"a", [{"href", "/a"}], ["1"] },
+      {"a", [{"href", "/c"}], ["3"] },
+      {"a", [{"href", "/e"}], ["5"] }
+    ]
+
+    assert Floki.find(html, "a:first-child") == [
+      {"a", [{"href", "/a"}], ["1"] }
+    ]
+  end
+
   # Floki.find/2 - XML and invalid HTML
 
   test "get elements inside a XML" do


### PR DESCRIPTION
This version does search for specific node positions (`integers`) and `even/odd` positions. It does not work with complex expressions like "2n+1" yet.

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child

It closes #64 .