### PR TITLE
Add complex selectors for filter out

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -1,6 +1,5 @@
 defmodule Floki do
-  alias Floki.{Finder, Parser, FilterOut}
-  alias Floki.HTMLTree.Text
+  alias Floki.{Finder, Parser, FilterOut, HTMLTree}
 
   @moduledoc """
   Floki is a simple HTML parser that enables search for nodes using CSS selectors.
@@ -146,12 +145,12 @@ defmodule Floki do
 
     {tree, results} = Finder.find(html_as_tuple, selector)
 
-    Enum.map(results, fn(html_node) -> as_tuple(tree, html_node) end)
+    Enum.map(results, fn(html_node) -> HTMLTree.to_tuple(tree, html_node) end)
   end
   def find(html_tree_as_tuple, selector) do
     {tree, results} = Finder.find(html_tree_as_tuple, selector)
 
-    Enum.map(results, fn(html_node) -> as_tuple(tree, html_node) end)
+    Enum.map(results, fn(html_node) -> HTMLTree.to_tuple(tree, html_node) end)
   end
 
   def transform(html_tree_list, transformation) when is_list(html_tree_list) do
@@ -314,14 +313,5 @@ defmodule Floki do
   end
   def filter_out(elements, selector) do
     FilterOut.filter_out(elements, selector)
-  end
-
-  defp as_tuple(_tree, %Text{content: text}), do: text
-  defp as_tuple(tree, html_node) do
-    children = html_node.children_nodes_ids
-               |> Enum.reverse
-               |> Enum.map(fn(id) -> as_tuple(tree, Map.get(tree.nodes, id)) end)
-
-    {html_node.type, html_node.attributes, children}
   end
 end

--- a/lib/floki/filter_out.ex
+++ b/lib/floki/filter_out.ex
@@ -52,7 +52,7 @@ defmodule Floki.FilterOut do
     children = html_node.children_nodes_ids
                |> Enum.reverse
                |> Enum.map(fn(id) -> Map.get(tree.nodes, id) end)
-               |> Enum.map(fn(node) -> as_tuple(tree, node) end)
+               |> Enum.map(fn(html_node) -> as_tuple(tree, html_node) end)
 
     {html_node.type, html_node.attributes, children}
   end

--- a/lib/floki/filter_out.ex
+++ b/lib/floki/filter_out.ex
@@ -8,8 +8,31 @@ defmodule Floki.FilterOut do
 
   @spec filter_out(html_tree, selector) :: tuple | list
 
+  def filter_out(html_tree, :comment) do
+    mapper(html_tree, :comment)
+  end
   def filter_out(html_tree, selector) do
-    mapper(html_tree, selector)
+    case Floki.Finder.find(html_tree, selector) do
+      {:empty_tree, _} ->
+        html_tree
+      {tree, results} ->
+        new_tree = Enum.reduce(results, tree, fn(html_node, tree) ->
+          Floki.HTMLTree.delete_node(tree, html_node)
+        end)
+
+        html_as_tuples = Enum.map(new_tree.root_nodes_ids, fn(node_id) ->
+          root = Map.get(new_tree.nodes, node_id)
+
+          as_tuple(new_tree, root)
+        end)
+
+        case html_tree do
+          tree when is_tuple(tree) ->
+            hd(html_as_tuples)
+          trees when is_list(trees) ->
+            html_as_tuples
+        end
+    end
   end
 
   defp filter({nodetext, _, _}, selector) when nodetext === selector, do: false
@@ -23,4 +46,14 @@ defmodule Floki.FilterOut do
     {nodetext, x, mapper(y, selector)}
   end
   defp mapper(nodetext, _), do: nodetext
+
+  defp as_tuple(_tree, %Floki.HTMLTree.Text{content: text}), do: text
+  defp as_tuple(tree, html_node) do
+    children = html_node.children_nodes_ids
+               |> Enum.reverse
+               |> Enum.map(fn(id) -> Map.get(tree.nodes, id) end)
+               |> Enum.map(fn(node) -> as_tuple(tree, node) end)
+
+    {html_node.type, html_node.attributes, children}
+  end
 end

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -9,7 +9,7 @@ defmodule Floki.HTMLTree do
   defstruct nodes: %{}, root_nodes_ids: [], node_ids: []
 
   alias Floki.HTMLTree
-  alias Floki.HTMLTree.{HTMLNode, Text, IDSeeder}
+  alias Floki.HTMLTree.{HTMLNode, Text, Comment, IDSeeder}
 
   def build({tag, attrs, children}) do
     root_id = IDSeeder.seed([])
@@ -44,14 +44,7 @@ defmodule Floki.HTMLTree do
 
   defp do_delete(tree, [], []), do: tree
   defp do_delete(tree, [html_node | t], stack_ids) do
-    new_tree_nodes = Map.delete(tree.nodes, html_node.node_id)
-    parent_node = Map.get(tree.nodes, html_node.parent_node_id)
-
-    if parent_node do
-      new_children_node_ids = List.delete(parent_node.children_nodes_ids, html_node.node_id)
-      new_parent = %{parent_node | children_nodes_ids: new_children_node_ids}
-      new_tree_nodes = %{new_tree_nodes | new_parent.node_id => new_parent}
-    end
+    new_tree_nodes = delete_node_from_nodes(tree.nodes, html_node)
 
     ids_for_stack = get_ids_for_delete_stack(html_node)
 
@@ -66,6 +59,19 @@ defmodule Floki.HTMLTree do
                  |> Map.values
 
     do_delete(tree, html_nodes, [])
+  end
+
+  defp delete_node_from_nodes(nodes, html_node) do
+    tree_nodes = Map.delete(nodes, html_node.node_id)
+    parent_node = Map.get(nodes, html_node.parent_node_id)
+
+    if parent_node do
+      children_ids = List.delete(parent_node.children_nodes_ids, html_node.node_id)
+      new_parent = %{parent_node | children_nodes_ids: children_ids}
+      %{tree_nodes | new_parent.node_id => new_parent}
+    else
+      tree_nodes
+    end
   end
 
   defp get_ids_for_delete_stack(%HTMLNode{children_nodes_ids: ids}), do: ids
@@ -84,7 +90,15 @@ defmodule Floki.HTMLTree do
     %{tree | nodes: nodes, node_ids: [new_id | tree.node_ids]}
     |> build_tree(child_children, new_id, [{parent_id, children} | stack])
   end
+  defp build_tree(tree, [{:comment, comment} | children], parent_id, stack) do
+    new_id = IDSeeder.seed(tree.node_ids)
+    new_node = %Comment{content: comment, node_id: new_id, parent_node_id: parent_id}
 
+    nodes = put_new_node(tree.nodes, new_node)
+
+    %{tree | nodes: nodes, node_ids: [new_id | tree.node_ids]}
+    |> build_tree(children, parent_id, stack)
+  end
   defp build_tree(tree, [text | children], parent_id, stack) when is_binary(text) do
     new_id = IDSeeder.seed(tree.node_ids)
     new_node = %Text{content: text, node_id: new_id, parent_node_id: parent_id}

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -45,6 +45,14 @@ defmodule Floki.HTMLTree do
   defp do_delete(tree, [], []), do: tree
   defp do_delete(tree, [html_node | t], stack_ids) do
     new_tree_nodes = Map.delete(tree.nodes, html_node.node_id)
+    parent_node = Map.get(tree.nodes, html_node.parent_node_id)
+
+    if parent_node do
+      new_children_node_ids = List.delete(parent_node.children_nodes_ids, html_node.node_id)
+      new_parent = %{parent_node | children_nodes_ids: new_children_node_ids}
+      new_tree_nodes = %{new_tree_nodes | new_parent.node_id => new_parent}
+    end
+
     ids_for_stack = get_ids_for_delete_stack(html_node)
 
     do_delete(%{tree | nodes: new_tree_nodes,

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -38,6 +38,31 @@ defmodule Floki.HTMLTree do
     Enum.reduce(html_tuples, %HTMLTree{}, reducer)
   end
 
+  def delete_node(tree, html_node) do
+    do_delete(tree, [html_node], [])
+  end
+
+  defp do_delete(tree, [], []), do: tree
+  defp do_delete(tree, [html_node | t], stack_ids) do
+    new_tree_nodes = Map.delete(tree.nodes, html_node.node_id)
+    ids_for_stack = get_ids_for_delete_stack(html_node)
+
+    do_delete(%{tree | nodes: new_tree_nodes,
+                       node_ids: List.delete(tree.node_ids, html_node.node_id),
+                       root_nodes_ids: List.delete(tree.root_nodes_ids, html_node.node_id)},
+              t, ids_for_stack ++ stack_ids)
+  end
+  defp do_delete(tree, [], stack_ids) do
+    html_nodes = tree.nodes
+                 |> Map.take(stack_ids)
+                 |> Map.values
+
+    do_delete(tree, html_nodes, [])
+  end
+
+  defp get_ids_for_delete_stack(%HTMLNode{children_nodes_ids: ids}), do: ids
+  defp get_ids_for_delete_stack(_), do: []
+
   defp build_tree(tree, [], _, []), do: tree
   defp build_tree(tree, [{tag, attrs, child_children} | children], parent_id, stack) do
     new_id = IDSeeder.seed(tree.node_ids)

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -42,6 +42,16 @@ defmodule Floki.HTMLTree do
     do_delete(tree, [html_node], [])
   end
 
+  def to_tuple(_tree, %Text{content: text}), do: text
+  def to_tuple(_tree, %Comment{content: comment}), do: {:comment, comment}
+  def to_tuple(tree, html_node) do
+    children = html_node.children_nodes_ids
+               |> Enum.reverse
+               |> Enum.map(fn(id) -> to_tuple(tree, Map.get(tree.nodes, id)) end)
+
+    {html_node.type, html_node.attributes, children}
+  end
+
   defp do_delete(tree, [], []), do: tree
   defp do_delete(tree, [html_node | t], stack_ids) do
     new_tree_nodes = delete_node_from_nodes(tree.nodes, html_node)

--- a/lib/floki/html_tree/comment.ex
+++ b/lib/floki/html_tree/comment.ex
@@ -1,0 +1,6 @@
+defmodule Floki.HTMLTree.Comment do
+  @moduledoc false
+
+  # Represents a comment inside an HTML tree with reference to its parent node id.
+  defstruct content: "", node_id: nil, parent_node_id: nil
+end

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -4,7 +4,7 @@ defmodule Floki.Selector do
   """
 
   alias Floki.{Selector, AttributeSelector}
-  alias Floki.HTMLTree.{HTMLNode, Text}
+  alias Floki.HTMLTree.{HTMLNode, Text, Comment}
 
   defstruct id: nil,
             type: nil,
@@ -24,6 +24,7 @@ defmodule Floki.Selector do
   def match?({:comment, _comment}, _selector), do: false
   def match?({:pi, _xml, _xml_attrs}, _selector), do: false
   def match?(%Text{}, _), do: false
+  def match?(%Comment{}, _), do: false
   def match?(%HTMLNode{type: type, attributes: attributes}, selector) do
     Selector.match?({type, attributes, []}, selector)
   end

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -29,10 +29,20 @@ defmodule Floki.Selector.PseudoClass do
     parent_node = Map.get(tree.nodes, html_node.parent_node_id)
     children_nodes_ids = parent_node.children_nodes_ids
                          |> Enum.reverse
+                         |> filter_only_html_nodes(tree.nodes)
                          |> Enum.with_index(1)
 
     {_node_id, position} = Enum.find(children_nodes_ids, fn({id, _}) -> id == html_node.node_id end)
 
     position
+  end
+
+  defp filter_only_html_nodes(ids, nodes) do
+    Enum.filter(ids, fn(id) ->
+      case Map.get(nodes, id) do
+        %HTMLNode{} -> true
+        _ -> false
+      end
+    end)
   end
 end

--- a/test/floki/filter_out_test.exs
+++ b/test/floki/filter_out_test.exs
@@ -1,0 +1,9 @@
+defmodule Floki.FilterOutTest do
+  use ExUnit.Case, async: true
+
+  test "filter out elements with complex selectors" do
+    html = Floki.parse("<body> <div class=\"has\">one</div>  <div>two</div> </body>")
+
+    assert Floki.FilterOut.filter_out(html, "div[class]") == {"body", [], [{"div", [], ["two"]}]}
+  end
+end

--- a/test/floki/html_tree_test.exs
+++ b/test/floki/html_tree_test.exs
@@ -111,7 +111,7 @@ defmodule Floki.HTMLTreeTest do
      node_ids: [5, 1],
      nodes: %{
        1 => %HTMLNode{type: "html",
-                      children_nodes_ids: [5, 2],
+                      children_nodes_ids: [5],
                       node_id: 1},
        5 => %HTMLNode{type: "span",
                       parent_node_id: 1,

--- a/test/floki/html_tree_test.exs
+++ b/test/floki/html_tree_test.exs
@@ -2,7 +2,7 @@ defmodule Floki.HTMLTreeTest do
   use ExUnit.Case, async: true
 
   alias Floki.HTMLTree
-  alias Floki.HTMLTree.{HTMLNode, Text}
+  alias Floki.HTMLTree.{HTMLNode, Text, Comment}
 
   test "build the tuple tree into HTML tree" do
     link_attrs = [{"href", "/home"}]
@@ -16,26 +16,27 @@ defmodule Floki.HTMLTreeTest do
 
     assert HTMLTree.build(html_tuple) == %HTMLTree{
      root_nodes_ids: [1],
-     node_ids: [5, 4, 3, 2, 1],
+     node_ids: [6, 5, 4, 3, 2, 1],
      nodes: %{
        1 => %HTMLNode{type: "html",
-                      children_nodes_ids: [5, 2],
+                      children_nodes_ids: [6, 3, 2],
                       node_id: 1},
-       2 => %HTMLNode{type: "a",
+       2 => %Comment{content: "start of the stack", node_id: 2, parent_node_id: 1},
+       3 => %HTMLNode{type: "a",
                       attributes: link_attrs,
                       parent_node_id: 1,
-                      children_nodes_ids: [3],
-                      node_id: 2},
-       3 => %HTMLNode{type: "b",
-                      parent_node_id: 2,
                       children_nodes_ids: [4],
                       node_id: 3},
-       4 => %Text{content: "click me",
-                  parent_node_id: 3,
-                  node_id: 4},
-       5 => %HTMLNode{type: "span",
+       4 => %HTMLNode{type: "b",
+                      parent_node_id: 3,
+                      children_nodes_ids: [5],
+                      node_id: 4},
+       5 => %Text{content: "click me",
+                  parent_node_id: 4,
+                  node_id: 5},
+       6 => %HTMLNode{type: "span",
                       parent_node_id: 1,
-                      node_id: 5}
+                      node_id: 6}
      }
     }
   end
@@ -44,7 +45,6 @@ defmodule Floki.HTMLTreeTest do
     html_tuple_list = [
       {"html", [],
        [
-         {:comment, "start of the stack"},
          {"a", [{"href", "/home"}],
           [{"b", [], ["click me"]}]},
          {"span", [], []}]}

--- a/test/floki/html_tree_test.exs
+++ b/test/floki/html_tree_test.exs
@@ -129,4 +129,44 @@ defmodule Floki.HTMLTreeTest do
       nodes: %{}
     }
   end
+
+  test "build tuple representation of tree" do
+    html_tree = %HTMLTree{
+     root_nodes_ids: [1],
+     node_ids: [6, 5, 4, 3, 2, 1],
+     nodes: %{
+       1 => %HTMLNode{type: "html",
+                      children_nodes_ids: [6, 3, 2],
+                      node_id: 1},
+       2 => %Comment{content: "start of the stack", node_id: 2, parent_node_id: 1},
+       3 => %HTMLNode{type: "a",
+                      attributes: [{"class", "link"}],
+                      parent_node_id: 1,
+                      children_nodes_ids: [4],
+                      node_id: 3},
+       4 => %HTMLNode{type: "b",
+                      parent_node_id: 3,
+                      children_nodes_ids: [5],
+                      node_id: 4},
+       5 => %Text{content: "click me",
+                  parent_node_id: 4,
+                  node_id: 5},
+       6 => %HTMLNode{type: "span",
+                      parent_node_id: 1,
+                      node_id: 6}
+      }
+    }
+
+    expected_tuple =
+      {"html", [],
+       [
+         {:comment, "start of the stack"},
+         {"a", [{"class", "link"}],
+          [{"b", [], ["click me"]}]},
+         {"span", [], []}]}
+
+    assert HTMLTree.to_tuple(html_tree, %HTMLNode{type: "html",
+                                                  children_nodes_ids: [6, 3, 2],
+                                                  node_id: 1}) == expected_tuple
+  end
 end

--- a/test/floki/html_tree_test.exs
+++ b/test/floki/html_tree_test.exs
@@ -4,7 +4,7 @@ defmodule Floki.HTMLTreeTest do
   alias Floki.HTMLTree
   alias Floki.HTMLTree.{HTMLNode, Text}
 
-  test "build the tuple tree into html tree" do
+  test "build the tuple tree into HTML tree" do
     link_attrs = [{"href", "/home"}]
     html_tuple =
       {"html", [],
@@ -41,12 +41,11 @@ defmodule Floki.HTMLTreeTest do
   end
 
   test "build HTML tuple list" do
-    link_attrs = [{"href", "/home"}]
     html_tuple_list = [
       {"html", [],
        [
          {:comment, "start of the stack"},
-         {"a", link_attrs,
+         {"a", [{"href", "/home"}],
           [{"b", [], ["click me"]}]},
          {"span", [], []}]}
     ]
@@ -59,7 +58,7 @@ defmodule Floki.HTMLTreeTest do
                       children_nodes_ids: [5, 2],
                       node_id: 1},
        2 => %HTMLNode{type: "a",
-                     attributes: link_attrs,
+                     attributes: [{"href", "/home"}],
                      parent_node_id: 1,
                      children_nodes_ids: [3],
                      node_id: 2},
@@ -74,6 +73,60 @@ defmodule Floki.HTMLTreeTest do
                       parent_node_id: 1,
                       node_id: 5}
      }
+    }
+  end
+
+  test "delete HTML node from tree" do
+    tree = %HTMLTree{
+     root_nodes_ids: [1],
+     node_ids: [5, 4, 3, 2, 1],
+     nodes: %{
+       1 => %HTMLNode{type: "html",
+                      children_nodes_ids: [5, 2],
+                      node_id: 1},
+       2 => %HTMLNode{type: "a",
+                     parent_node_id: 1,
+                     children_nodes_ids: [3],
+                     node_id: 2},
+       3 => %HTMLNode{type: "b",
+                      parent_node_id: 2,
+                      children_nodes_ids: [4],
+                      node_id: 3},
+       4 => %Text{content: "click me",
+                  parent_node_id: 3,
+                  node_id: 4},
+       5 => %HTMLNode{type: "span",
+                      parent_node_id: 1,
+                      node_id: 5}
+     }
+    }
+
+    html_node = %HTMLNode{type: "a",
+                          parent_node_id: 1,
+                          children_nodes_ids: [3],
+                          node_id: 2}
+
+    assert HTMLTree.delete_node(tree, html_node) == %HTMLTree{
+     root_nodes_ids: [1],
+     node_ids: [5, 1],
+     nodes: %{
+       1 => %HTMLNode{type: "html",
+                      children_nodes_ids: [5, 2],
+                      node_id: 1},
+       5 => %HTMLNode{type: "span",
+                      parent_node_id: 1,
+                      node_id: 5}
+     }
+    }
+
+    html_node = %HTMLNode{type: "html",
+                          children_nodes_ids: [5, 2],
+                          node_id: 1}
+
+    assert HTMLTree.delete_node(tree, html_node) == %HTMLTree{
+      root_nodes_ids: [],
+      node_ids: [],
+      nodes: %{}
     }
   end
 end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -489,8 +489,10 @@ defmodule FlokiTest do
     <html>
     <body>
       <a href="/a">1</a>
+      ignores this text
       <a href="/b">2</a>
       <a href="/c">3</a>
+      <!-- also ignores this comment -->
       <a href="/d">4</a>
       <a href="/e">5</a>
     </html>


### PR DESCRIPTION
It makes filter out work with complex selectors and not only tag name. It closes #61 .
This also fixes some issues:

- Sibling selector not working as expected when there is a text node in the middle - closes #79;
- `nth-child` not ignoring text or comment nodes;
- `HTMLTree.to_tuple/2` not building comments back.