### PR TITLE
get descendant node ids recursively rather than using a range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
       elixir: 1.3.4
     - otp_release: 19.0
       elixir: 1.3.4
+    - otp_release: 18.3
+      elixir: 1.4.0
+    - otp_release: 19.0
+      elixir: 1.4.0
 
 sudo: false
 

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -155,8 +155,7 @@ defmodule Floki.Finder do
   defp traverse_with(%Combinator{match_type: :descendant, selector: s}, tree, stack) do
     results =
       Enum.flat_map(stack, fn(html_node) ->
-        sibling_ids = get_siblings(html_node, tree)
-        ids_to_match = get_ids_for_decendant_match(html_node.node_id, sibling_ids, tree.node_ids)
+        ids_to_match = get_descendant_ids(html_node.node_id, tree)
         nodes = ids_to_match
                 |> get_nodes(tree)
 
@@ -198,15 +197,13 @@ defmodule Floki.Finder do
     end)
   end
 
-  # It takes all ids until the next sibling, that represents the ids under a given sub-tree
-  defp get_ids_for_decendant_match(node_id, sibling_ids, ids) do
-    [_ | ids_after] = ids
-                      |> Enum.reverse
-                      |> Enum.drop_while(fn(id) -> id != node_id end)
-
-    case sibling_ids do
-      [] -> ids_after
-      [sibling_id | _] -> Enum.take_while(ids_after, fn(id) -> id != sibling_id end)
+  # finds all descendant node ids recursively through the tree
+  defp get_descendant_ids(node_id, tree) do
+    case get_node(node_id, tree) do
+      %{children_nodes_ids: node_ids} ->
+        node_ids ++ Enum.flat_map(node_ids, &( get_descendant_ids(&1, tree) ))
+      _ ->
+        []
     end
   end
 end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -607,4 +607,16 @@ defmodule FlokiTest do
     transform = Floki.transform(elements, transformation)
     assert transform |> Floki.find("a") |> Floki.attribute("href") == ["https://google.com", "https://elixir-lang.org", "https://java.com"]
   end
+
+  test "finding leaf nodes" do
+    html = """
+      <html>
+      <body>
+      <div id="messageBox" class="legacyErrors"><div class="messageBox error"><h2 class="accessAid">Error Message</h2><p>There has been an error in your account.</p></div></div>
+      <div id="main" class="legacyErrors"><p>Separate Error Message</p></div>
+      </body>
+      </html>
+      """
+    assert Floki.find(html, ".messageBox p") == [{"p", [], ["There has been an error in your account."]}]
+  end
 end


### PR DESCRIPTION
Attempt at fixing #84 

Rather than finding all node_ids in a given range (using the next sibling as an upper-bound), find all the children by recursively walking down the tree looking for leaf nodes.

I've also added the test case from #84, although I'm not sure that putting that test in `test/floki_test.exs` is the best place for it.

/cc @philss 