### PR TITLE
Duplicate reversed descendant matches

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -52,6 +52,7 @@ defmodule Floki.Finder do
       |> Enum.reverse
       |> get_nodes(tree)
       |> Enum.flat_map(fn(html_node) -> get_matches_for_selectors(tree, html_node, selectors) end)
+      |> Enum.uniq
 
     {tree, results}
   end
@@ -201,7 +202,7 @@ defmodule Floki.Finder do
   defp get_descendant_ids(node_id, tree) do
     case get_node(node_id, tree) do
       %{children_nodes_ids: node_ids} ->
-        node_ids ++ Enum.flat_map(node_ids, &( get_descendant_ids(&1, tree) ))
+        Enum.reverse(node_ids) ++ Enum.flat_map(node_ids, &( get_descendant_ids(&1, tree) ))
       _ ->
         []
     end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -619,4 +619,21 @@ defmodule FlokiTest do
       """
     assert Floki.find(html, ".messageBox p") == [{"p", [], ["There has been an error in your account."]}]
   end
+
+  test "descendant matches are returned in order and without duplicates" do
+    html = """
+      <html><body>
+        <div>
+          <div>
+            <hr>
+              <p>1</p>
+              <p>2</p>
+              <p>3</p>
+            </hr>
+          </div>
+        </div>
+      </body></html>
+      """
+    assert Floki.find(html, "div p") == [{"p", [], ["1"]},{"p", [], ["2"]},{"p", [], ["3"]}]
+  end
 end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -622,17 +622,15 @@ defmodule FlokiTest do
 
   test "descendant matches are returned in order and without duplicates" do
     html = """
-      <html><body>
+      <div>
         <div>
-          <div>
-            <hr>
-              <p>1</p>
-              <p>2</p>
-              <p>3</p>
-            </hr>
-          </div>
+          <hr>
+            <p>1</p>
+            <p>2</p>
+            <p>3</p>
+          </hr>
         </div>
-      </body></html>
+      </div>
       """
     assert Floki.find(html, "div p") == [{"p", [], ["1"]},{"p", [], ["2"]},{"p", [], ["3"]}]
   end


### PR DESCRIPTION
Thanks for all of your help with #85 

I tried upgrading to `v0.12.1` in my project and ran into two small issues. This PR attempts to fix one of those two.  `Finder` was returning some duplicate nodes and the nodes were not in the same order that they occured in the html tree.

I've added a spec to highlight this and tried to address it in `Finder`.