### PR TITLE
Text reversing

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -190,6 +190,9 @@ defmodule Floki do
       iex> Floki.text([{"div", [], ["hello world"]}])
       "hello world"
 
+      iex> Floki.text([{"p", [], ["1"]},{"p", [], ["2"]}])
+      "12"
+
   """
 
   @spec text(html_tree | binary) :: binary

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -29,7 +29,7 @@ defmodule Floki.HTMLTree do
 
         %{tree | nodes: Map.put(tree.nodes, root_id, root_node),
                  node_ids: [root_id | tree.node_ids],
-                 root_nodes_ids: [root_id | tree.root_nodes_ids]}
+                 root_nodes_ids: tree.root_nodes_ids ++ [root_id]}
         |> build_tree(children, root_id, [])
       (_, tree) ->
         tree

--- a/test/floki/filter_out_test.exs
+++ b/test/floki/filter_out_test.exs
@@ -6,4 +6,10 @@ defmodule Floki.FilterOutTest do
 
     assert Floki.FilterOut.filter_out(html, "div[class]") == {"body", [], [{"div", [], ["two"]}]}
   end
+
+  test "filter out returns the elements in the same order they were passed in" do
+    nodes = [{"p", [], ["1"]},{"p", [], ["2"]}]
+    assert Floki.FilterOut.filter_out(nodes, "script") == nodes
+    assert Floki.FilterOut.filter_out(nodes, :comment) == nodes
+  end
 end

--- a/test/floki/html_tree_test.exs
+++ b/test/floki/html_tree_test.exs
@@ -76,6 +76,31 @@ defmodule Floki.HTMLTreeTest do
     }
   end
 
+  test "builds the root node ids in the right order" do
+    tuples = [{"p", [], ["1"]},{"p", [], ["2"]}]
+    tree = HTMLTree.build(tuples)
+    assert tree == %HTMLTree{
+      root_nodes_ids: [1, 3],
+      node_ids: [4, 3, 2, 1],
+      nodes: %{
+        1 => %HTMLNode{type: "p",
+                       children_nodes_ids: [2],
+                       node_id: 1},
+        2 => %Text{content: "1",
+                   node_id: 2,
+                   parent_node_id: 1},
+        3 => %HTMLNode{attributes: [],
+                       children_nodes_ids: [4],
+                       node_id: 3,
+                       parent_node_id: nil,
+                       type: "p"},
+        4 => %Text{content: "2",
+                   node_id: 4,
+                   parent_node_id: 3},
+      }
+    }
+  end
+
   test "delete HTML node from tree" do
     tree = %HTMLTree{
      root_nodes_ids: [1],


### PR DESCRIPTION
I first noticed this problem manifest when I would do:

```
iex> Floki.text([{"p", [], ["1"]},{"p", [], ["2"]}])
"21"
```

The order of the text was reverse of the order of the nodes being passed in. Digging in further it turned that that the reversing was happening during the `FilterOut` step, and digging in past that it turned out be caused when `Finder` constructs an `HTMLTree` struct because it was recording the `root_node_ids` in reverse order of what got passed in.

I've added a few unit tests as I was tracking this down, but we can remove most of them if you prefer. It might only be useful to keep the unit test added to `HTMLTree` since that was the root cause in the end, but I figured you might want to keep the coverage around from the other tests just in case.