### PR TITLE
Only Mochiweb_html

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Floki.Mixfile do
      name: "Floki",
      version: @version,
      description: @description,
-     elixir: ">= 1.2.0",
+     elixir: ">= 1.4.0",
      package: package(),
      deps: deps(),
      source_url: "https://github.com/philss/floki",
@@ -17,12 +17,13 @@ defmodule Floki.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :mochiweb]]
+    [extra_applications: [:logger],
+     mod: {Floki, []}]
   end
 
   defp deps do
     [
-      {:mochiweb, "~> 2.15"},
+      {:mochiweb_html, "~> 2.15"},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.14", only: :dev},
       {:credo,">= 0.0.0", only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -17,8 +17,7 @@ defmodule Floki.Mixfile do
   end
 
   def application do
-    [extra_applications: [:logger],
-     mod: {Floki, []}]
+    [extra_applications: [:logger]]
   end
 
   defp deps do

--- a/mix.lock
+++ b/mix.lock
@@ -4,4 +4,5 @@
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
+  "mochiweb_html": {:hex, :mochiweb_html, "2.15.0", "d7402e967d7f9f2912f8befa813c37be62d5eeeddbbcb6fe986c44e01460d497", [:rebar3], []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}


### PR DESCRIPTION
I am working in a project where I am using Floki and rabbit_common libraries. Both libraries depend on mochijson2 and it caused dependency issues. After checking Floki, I saw that it only uses mochiweb_html, therefore I have tried to run Floki with only this dependency. Everything is working fine for me, hence; I propose to make lighter the load of 3rd party libraries in Floki.