### PR TITLE
Fix order of elements returned after a desdencent combinator search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed pseudo-class selectors that are used in conjunction with combinators - thanks @Eiji7
+- Fixed order of elements after search using descendant combinator - thanks @Eiji7
 
 ## [0.14.0] - 2017-02-07
 

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -112,7 +112,7 @@ defmodule Floki.Finder do
   # The stack serves as accumulator when there is another combinator to traverse.
   # So the scope of one combinator is the stack (or acc) or the parent one.
   defp traverse_with(_, _, []), do: []
-  defp traverse_with(nil, _, result), do: result
+  defp traverse_with(nil, _, results), do: results
   defp traverse_with(%Combinator{match_type: :child, selector: s}, tree, stack) do
     results =
       Enum.flat_map(stack, fn(html_node) ->
@@ -198,11 +198,12 @@ defmodule Floki.Finder do
     end)
   end
 
-  # finds all descendant node ids recursively through the tree
+  # finds all descendant node ids recursively through the tree preserving the order
   defp get_descendant_ids(node_id, tree) do
     case get_node(node_id, tree) do
       %{children_nodes_ids: node_ids} ->
-        Enum.reverse(node_ids) ++ Enum.flat_map(node_ids, &(get_descendant_ids(&1, tree)))
+        reversed_ids = Enum.reverse(node_ids)
+        reversed_ids ++ Enum.flat_map(reversed_ids, &(get_descendant_ids(&1, tree)))
       _ ->
         []
     end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -632,28 +632,61 @@ defmodule FlokiTest do
 
   test "finding leaf nodes" do
     html = """
-      <html>
-      <body>
-      <div id="messageBox" class="legacyErrors"><div class="messageBox error"><h2 class="accessAid">Error Message</h2><p>There has been an error in your account.</p></div></div>
-      <div id="main" class="legacyErrors"><p>Separate Error Message</p></div>
-      </body>
-      </html>
-      """
+    <html>
+    <body>
+    <div id="messageBox" class="legacyErrors">
+      <div class="messageBox error">
+        <h2 class="accessAid">Error Message</h2>
+        <p>There has been an error in your account.</p>
+      </div>
+    </div>
+    <div id="main" class="legacyErrors"><p>Separate Error Message</p></div>
+    </body>
+    </html>
+    """
     assert Floki.find(html, ".messageBox p") == [{"p", [], ["There has been an error in your account."]}]
   end
 
   test "descendant matches are returned in order and without duplicates" do
     html = """
-      <div>
-        <div>
-          <hr>
-            <p>1</p>
-            <p>2</p>
-            <p>3</p>
-          </hr>
-        </div>
-      </div>
-      """
-    assert Floki.find(html, "div p") == [{"p", [], ["1"]},{"p", [], ["2"]},{"p", [], ["3"]}]
+    <!doctype html>
+    <html>
+      <body>
+        <div class="data-view">Foo</div>
+        <table summary="license-detail">
+          <tbody>
+            <tr>
+              <th>
+                <span>Name:</span>
+              </th>
+              <td class="data-view"><span class="surname">Silva</span>, <span>Joana</span> <span>Maria</span></td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <span>License Type:</span>
+              </th>
+              <td class="data-view">Naturopathic Doctor</td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <span>Expiration Date:</span>
+              </th>
+              <td class="data-view">06/30/2017</td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="data-view">Bar</div>
+      </body>
+    </html>
+    """
+
+    expected = [
+      {"td", [{"class", "data-view"}], [{"span", [{"class", "surname"}], ["Silva"]}, ", ",
+                                        {"span", [], ["Joana"]}, {"span", [], ["Maria"]}]},
+      {"td", [{"class", "data-view"}], ["Naturopathic Doctor"]},
+      {"td", [{"class", "data-view"}], ["06/30/2017"]},
+    ]
+
+    assert Floki.find(html, "table[summary='license-detail'] td.data-view") == expected
   end
 end


### PR DESCRIPTION
The problem was related with the order that we were returning the
elements of a search using the descendant combinator.

The solution is to reverse also the nodes in the recursive call that
will reach all the children nodes.

Issue related: https://github.com/philss/floki/issues/98