### PR TITLE
add support for contains selector

### DIFF
--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -105,6 +105,8 @@ defmodule Floki.Selector do
         PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: 1})
       "not" ->
         !Selector.match?(html_node, pseudo_class.value, tree)
+      "fl-contains" ->
+        PseudoClass.match_contains?(tree, html_node, pseudo_class)
       unknown_pseudo_class ->
         Logger.warn("Pseudo-class #{inspect unknown_pseudo_class} is not implemented. Ignoring.")
         false

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -6,7 +6,7 @@ defmodule Floki.Selector.PseudoClass do
   # Represents a pseudo-class selector
   defstruct name: "", value: nil
 
-  alias Floki.HTMLTree.HTMLNode
+  alias Floki.HTMLTree.{HTMLNode, Text}
 
   def match_nth_child?(_, %HTMLNode{parent_node_id: nil}, _), do: false
   def match_nth_child?(tree, html_node, %__MODULE__{value: position}) when is_integer(position) do
@@ -23,6 +23,17 @@ defmodule Floki.Selector.PseudoClass do
   def match_nth_child?(_, _, %__MODULE__{value: expression}) do
     Logger.warn("Pseudo-class nth-child with expressions like #{inspect expression} are not supported yet. Ignoring.")
     false
+  end
+
+  def match_contains?(tree, html_node, %__MODULE__{value: value}) do
+    res = Enum.find(html_node.children_nodes_ids, fn(id) ->
+      case Map.get(tree.nodes, id) do
+        %Text{content: content} -> content =~ value
+        _ -> false
+      end
+    end)
+
+    res != nil
   end
 
   defp node_position(tree, html_node) do

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -65,6 +65,10 @@ defmodule Floki.SelectorParser do
     pseudo_class = selector.pseudo_class
     do_parse(t, %{selector | pseudo_class: %{pseudo_class | value: to_string(pattern)}})
   end
+  defp do_parse([{:pseudo_class_quoted, _, pattern} | t], selector) do
+    pseudo_class = selector.pseudo_class
+    do_parse(t, %{selector | pseudo_class: %{pseudo_class | value: to_string(pattern)}})
+  end
   defp do_parse([{:pseudo_class_generic_value, _, value} | t], selector) do
     s = case selector.pseudo_class do
           %PseudoClass{name: "not"} ->

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -24,6 +24,7 @@ Rules.
 \({ODD}\)                            : {token, {pseudo_class_odd, TokenLine}}.
 \({EVEN}\)                           : {token, {pseudo_class_even, TokenLine}}.
 \({PSEUDO_PATT}\)                    : {token, {pseudo_class_pattern, TokenLine, remove_wrapper(TokenChars)}}.
+\({QUOTED}\)                         : {token, {pseudo_class_quoted, TokenLine, remove_wrapper(remove_wrapper(TokenChars))}}.
 {W}*\)                               : {token, {close_parentesis, TokenLine}}.
 ~=                                   : {token, {includes, TokenLine}}.
 \|=                                  : {token, {dash_match, TokenLine}}.

--- a/test/floki/selector_tokenizer_test.exs
+++ b/test/floki/selector_tokenizer_test.exs
@@ -96,5 +96,10 @@ defmodule Floki.SelectorTokenizerTest do
       {:pseudo, 1, 'nth-child'},
       {:pseudo_class_pattern, 1, '-n+6'}
     ]
+
+    assert SelectorTokenizer.tokenize(":fl-contains('foo')") == [
+      {:pseudo, 1, 'fl-contains'},
+      {:pseudo_class_quoted, 1, 'foo'}
+    ]
   end
 end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -554,6 +554,23 @@ defmodule FlokiTest do
     assert Floki.find(@xml, ":first-child") == expected
   end
 
+  test "contains pseudo-class" do
+    expected = [
+      {"p", [], ["Two"]}
+    ]
+
+    assert Floki.find(@html_without_html_tag, "p:fl-contains('Two')") == expected
+  end
+
+  test "contains psuedo-class with substring" do
+    expected = [
+      {"title", [], ["A podcast"]},
+      {"title", [], ["Another podcast"]}
+    ]
+
+    assert Floki.find(@xml, ":fl-contains(' podcast')") == expected
+  end
+
   # Floki.find/2 - XML and invalid HTML
 
   test "get elements inside a XML" do


### PR DESCRIPTION
This adds support for the `:contains` pseudo-class selector from jQuery.

Usage is demonstrated in the `contains pseudo-class` test.
