### PR TITLE
finder: add support for selectors that only include a pseudo-class

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -89,6 +89,9 @@ defmodule Floki.Finder do
   defp selector_match?(_tree, html_node, selector = %Selector{pseudo_class: nil}) do
     Selector.match?(html_node, selector)
   end
+  defp selector_match?(tree, html_node, selector = %Selector{id: nil, type: nil, classes: [], attributes: [], namespace: nil}) do
+    pseudo_class_match?(tree, html_node, selector)
+  end
   defp selector_match?(tree, html_node, selector) do
     Selector.match?(html_node, selector) && pseudo_class_match?(tree, html_node, selector)
   end

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -32,9 +32,10 @@ defmodule Floki.Selector.PseudoClass do
                          |> filter_only_html_nodes(tree.nodes)
                          |> Enum.with_index(1)
 
-    {_node_id, position} = Enum.find(children_nodes_ids, fn({id, _}) -> id == html_node.node_id end)
-
-    position
+    case Enum.find(children_nodes_ids, fn({id, _}) -> id == html_node.node_id end) do
+      {_node_id, position} -> position
+      _ -> nil
+    end
   end
 
   defp filter_only_html_nodes(ids, nodes) do

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -540,6 +540,16 @@ defmodule FlokiTest do
     assert first_result == second_result
   end
 
+  test "pseudo-class selector only" do
+    expected = [
+      {"channel", [], [{"title", [], ["A podcast"]}, {"link", [], ["www.foo.bar.com"]}]},
+      {"title", [], ["A podcast"]},
+      {"title", [], ["Another podcast"]}
+    ]
+
+    assert Floki.find(@xml, ":first-child") == expected
+  end
+
   # Floki.find/2 - XML and invalid HTML
 
   test "get elements inside a XML" do


### PR DESCRIPTION
This also tweaks node_position logic so that it can be called on non-HTMLNode elements.

Fixes #102.