### PR TITLE
Fix ":not()" pseudo class selector to accept pseudo-class selectors as args

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -96,6 +96,9 @@ defmodule Floki.Finder do
     Selector.match?(html_node, selector) && pseudo_class_match?(tree, html_node, selector)
   end
 
+  # TODO: move pseudo class match to inside "Selector".
+  # This is because we can't match recursively if there is another pseudo class inside
+  # "not", for example
   defp pseudo_class_match?(tree, html_node, selector) do
     pseudo_class = selector.pseudo_class
 

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -1,9 +1,10 @@
 defmodule Floki.Selector do
-  @moduledoc """
-  Represents a CSS selector. It also have functions to match nodes with a given selector.
-  """
+  require Logger
+  @moduledoc false
+  # Represents a CSS selector. It also have functions to match nodes with a given selector.
 
   alias Floki.{Selector, AttributeSelector}
+  alias Floki.Selector.PseudoClass
   alias Floki.HTMLTree.{HTMLNode, Text, Comment}
 
   defstruct id: nil,
@@ -14,31 +15,38 @@ defmodule Floki.Selector do
             pseudo_class: nil,
             combinator: nil
 
-  @doc """
-  Returns if a given node matches with a given selector.
-  """
-  def match?(_node, %Selector{id: nil, type: nil, classes: [], attributes: [], namespace: nil}) do
+  @doc false
+
+  # Returns if a given node matches with a given selector.
+  def match?(_node, %Selector{id: nil,
+                              type: nil,
+                              classes: [],
+                              attributes: [],
+                              namespace: nil,
+                              pseudo_class: nil,
+                              combinator: nil}, _tree) do
     false
   end
-  def match?(nil, _selector), do: false
-  def match?({:comment, _comment}, _selector), do: false
-  def match?({:pi, _xml, _xml_attrs}, _selector), do: false
-  def match?(%Text{}, _), do: false
-  def match?(%Comment{}, _), do: false
-  def match?(%HTMLNode{type: type, attributes: attributes}, selector) do
-    Selector.match?({type, attributes, []}, selector)
-  end
-  def match?(html_node, selector) do
+  def match?(nil, _selector, _tree), do: false
+  def match?({:comment, _comment}, _selector, _tree), do: false
+  def match?({:pi, _xml, _xml_attrs}, _selector, _tree), do: false
+  def match?(%Text{}, _selector, _tree), do: false
+  def match?(%Comment{}, _selector, _tree), do: false
+  #def match?(%HTMLNode{type: type, attributes: attributes}, selector, tree) do
+    #Selector.match?({type, attributes, []}, selector, tree)
+  #end
+  def match?(html_node, selector, tree) do
     id_match?(html_node, selector.id)
       && namespace_match?(html_node, selector.namespace)
       && type_match?(html_node, selector.type)
       && classes_matches?(html_node, selector.classes)
       && attributes_matches?(html_node, selector.attributes)
+      && pseudo_class_match?(html_node, selector.pseudo_class, tree)
   end
 
   defp id_match?(_node, nil), do: true
-  defp id_match?({_, [], _}, _), do: false
-  defp id_match?({_, attributes, _}, id) do
+  defp id_match?(%HTMLNode{attributes: []}, _), do: false
+  defp id_match?(%HTMLNode{attributes: attributes}, id) do
     Enum.any? attributes, fn(attribute) ->
       case attribute do
         {"id", ^id} -> true
@@ -49,7 +57,8 @@ defmodule Floki.Selector do
 
   defp namespace_match?(_node, nil), do: true
   defp namespace_match?(_node, "*"), do: true
-  defp namespace_match?({type_maybe_with_namespace, _, _}, namespace) do
+  defp namespace_match?(%HTMLNode{type: :pi}, _type), do: false
+  defp namespace_match?(%HTMLNode{type: type_maybe_with_namespace}, namespace) do
     case String.split(type_maybe_with_namespace, ":") do
       [ns, _type] ->
         ns == namespace
@@ -59,7 +68,8 @@ defmodule Floki.Selector do
 
   defp type_match?(_node, nil), do: true
   defp type_match?(_node, "*"), do: true
-  defp type_match?({type_maybe_with_namespace, _, _}, type) do
+  defp type_match?(%HTMLNode{type: :pi}, _type), do: false
+  defp type_match?(%HTMLNode{type: type_maybe_with_namespace}, type) do
     case String.split(type_maybe_with_namespace, ":") do
       [_ns, tp] ->
         tp == type
@@ -70,8 +80,8 @@ defmodule Floki.Selector do
   defp type_match?(_, _), do: false
 
   defp classes_matches?(_node, []), do: true
-  defp classes_matches?({_, [], _}, _), do: false
-  defp classes_matches?({_, attributes, _}, classes) do
+  defp classes_matches?(%HTMLNode{attributes: []}, _), do: false
+  defp classes_matches?(%HTMLNode{attributes: attributes}, classes) do
     Enum.all? classes, fn(class) ->
       selector = %AttributeSelector{match_type: :includes,
         attribute: "class",
@@ -82,10 +92,25 @@ defmodule Floki.Selector do
   end
 
   defp attributes_matches?(_node, []), do: true
-  defp attributes_matches?({_, [], _}, _), do: false
-  defp attributes_matches?({_, attributes, _}, attributes_selectors) do
+  defp attributes_matches?(%HTMLNode{attributes: []}, _), do: false
+  defp attributes_matches?(%HTMLNode{attributes: attributes}, attributes_selectors) do
     Enum.all? attributes_selectors, fn(attribute_selector) ->
       AttributeSelector.match?(attributes, attribute_selector)
+    end
+  end
+
+  defp pseudo_class_match?(_html_node, nil, _tree), do: true
+  defp pseudo_class_match?(html_node, pseudo_class, tree) do
+    case pseudo_class.name do
+      "nth-child" ->
+        PseudoClass.match_nth_child?(tree, html_node, pseudo_class)
+      "first-child" ->
+        PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: 1})
+      "not" ->
+        !Selector.match?(html_node, pseudo_class.value, tree)
+      unknown_pseudo_class ->
+        Logger.warn("Pseudo-class #{inspect unknown_pseudo_class} is not implemented. Ignoring.")
+        false
     end
   end
 end

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -32,9 +32,6 @@ defmodule Floki.Selector do
   def match?({:pi, _xml, _xml_attrs}, _selector, _tree), do: false
   def match?(%Text{}, _selector, _tree), do: false
   def match?(%Comment{}, _selector, _tree), do: false
-  #def match?(%HTMLNode{type: type, attributes: attributes}, selector, tree) do
-    #Selector.match?({type, attributes, []}, selector, tree)
-  #end
   def match?(html_node, selector, tree) do
     id_match?(html_node, selector.id)
       && namespace_match?(html_node, selector.namespace)

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -32,10 +32,9 @@ defmodule Floki.Selector.PseudoClass do
                          |> filter_only_html_nodes(tree.nodes)
                          |> Enum.with_index(1)
 
-    case Enum.find(children_nodes_ids, fn({id, _}) -> id == html_node.node_id end) do
-      {_node_id, position} -> position
-      _ -> nil
-    end
+    {_node_id, position} = Enum.find(children_nodes_ids, fn({id, _}) -> id == html_node.node_id end)
+
+    position
   end
 
   defp filter_only_html_nodes(ids, nodes) do

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -4,6 +4,7 @@ IDENTIFIER = [-A-Za-z0-9_]+
 QUOTED = (\"[^"]*\"|\'[^']*\')
 PARENTESIS = \([^)]*\)
 INT = [0-9]+
+NOT = (n|N)(o|O)(t|T)
 ODD = (o|O)(d|D)(d|D)
 EVEN = (e|E)(v|V)(e|E)(n|N)
 PSEUDO_PATT = (\+|-)?({INT})?(n|N)((\+|-){INT})?
@@ -17,12 +18,13 @@ Rules.
 {SYMBOL}                             : {token, {TokenChars, TokenLine}}.
 #{IDENTIFIER}                        : {token, {hash, TokenLine, tail(TokenChars)}}.
 \.{IDENTIFIER}                       : {token, {class, TokenLine, tail(TokenChars)}}.
+\:{NOT}\(                            : {token, {pseudo_not, TokenLine}}.
 \:{IDENTIFIER}                       : {token, {pseudo, TokenLine, tail(TokenChars)}}.
 \({INT}\)                            : {token, {pseudo_class_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
 \({ODD}\)                            : {token, {pseudo_class_odd, TokenLine}}.
 \({EVEN}\)                           : {token, {pseudo_class_even, TokenLine}}.
 \({PSEUDO_PATT}\)                    : {token, {pseudo_class_pattern, TokenLine, remove_wrapper(TokenChars)}}.
-{PARENTESIS}                         : {token, {pseudo_class_generic_value, TokenLine, remove_wrapper(TokenChars)}}.
+{W}*\)                               : {token, {close_parentesis, TokenLine}}.
 ~=                                   : {token, {includes, TokenLine}}.
 \|=                                  : {token, {dash_match, TokenLine}}.
 \^=                                  : {token, {prefix_match, TokenLine}}.
@@ -36,7 +38,6 @@ Rules.
 {W}*\|{W}*                           : {token, {namespace_pipe, TokenLine}}.
 {W}+                                 : {token, {space, TokenLine}}.
 .                                    : {token, {unknown, TokenLine, TokenChars}}.
-
 
 Erlang code.
 

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -136,6 +136,14 @@ defmodule Floki.SelectorParserTest do
       pseudo_class: %PseudoClass{name: "not", value: %Selector{classes: ["bar"]}}
     }
 
+    assert SelectorParser.parse("li:not(:nth-child(2)) a") == %Selector{
+      type: "li",
+      pseudo_class: %PseudoClass{name: "not",
+                                 value: %Selector{pseudo_class: %PseudoClass{name: "nth-child",
+                                                  value: 2}}},
+      combinator: %Combinator{match_type: :descendant, selector: %Selector{type: "a"}}
+    }
+
     assert SelectorParser.parse("a.foo:not(.bar > .baz)") == %Selector{
       type: "a",
       classes: ["foo"],

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -532,12 +532,16 @@ defmodule FlokiTest do
     """
     first_result = Floki.find(html, "a.link:not(.bar)")
     second_result = Floki.find(html, "div#links > a.link:not(.bar)")
+    third_result = Floki.find(html, "a.link:not(:nth-child(2))")
+
     expected_result = [
       {"a", [{"class", "link foo"}], ["A foo"]},
       {"a", [{"class", "link baz"}], ["A baz"]}
     ]
+
     assert first_result == expected_result
     assert first_result == second_result
+    assert third_result == expected_result
   end
 
   test "pseudo-class selector only" do


### PR DESCRIPTION

This PR fixes: https://github.com/philss/floki/issues/100