### PR TITLE
update pseudo not selector to allow multiple selections in ()

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -58,7 +58,7 @@ defmodule Floki.Finder do
 
   defp get_selectors(selector_as_string) do
     selector_as_string
-    |> String.split(~r/,(?![^(]*\))/i)
+    |> String.split(",")
     |> Enum.map(fn(s) ->
       tokens = SelectorTokenizer.tokenize(s)
 

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -58,7 +58,7 @@ defmodule Floki.Finder do
 
   defp get_selectors(selector_as_string) do
     selector_as_string
-    |> String.split(",")
+    |> String.split(~r/,(?![^(]*\))/i)
     |> Enum.map(fn(s) ->
       tokens = SelectorTokenizer.tokenize(s)
 

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -23,7 +23,7 @@ defmodule Floki.Selector do
                               classes: [],
                               attributes: [],
                               namespace: nil,
-                              pseudo_class: nil,
+                              pseudo_classes: [],
                               combinator: nil}, _tree) do
     false
   end
@@ -38,7 +38,7 @@ defmodule Floki.Selector do
       && type_match?(html_node, selector.type)
       && classes_matches?(html_node, selector.classes)
       && attributes_matches?(html_node, selector.attributes)
-      && pseudo_class_match?(html_node, selector.pseudo_class, tree)
+      && pseudo_classes_match?(html_node, selector.pseudo_classes, tree)
   end
 
   defp id_match?(_node, nil), do: true
@@ -96,10 +96,11 @@ defmodule Floki.Selector do
     end
   end
 
-  defp pseudo_class_match?(_html_node, nil, _tree), do: true
-  defp pseudo_class_match?(html_node, pseudo_classes, tree) when is_list(pseudo_classes) do
-    Enum.all?(pseudo_classes, &(pseudo_class_match?(html_node, &1, tree)))
+  defp pseudo_classes_match?(_html_node, [], _tree), do: true
+  defp pseudo_classes_match?(html_node, pseudo_classes, tree) do
+    Enum.all?(pseudo_classes, &pseudo_class_match?(html_node, &1, tree))
   end
+
   defp pseudo_class_match?(html_node, pseudo_class, tree) do
     case pseudo_class.name do
       "nth-child" ->
@@ -107,10 +108,7 @@ defmodule Floki.Selector do
       "first-child" ->
         PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: 1})
       "not" ->
-        case pseudo_class.value do
-          selectors when is_list(selectors) -> Enum.all?(selectors, &(!Selector.match?(html_node, &1, tree)))
-          selector -> !Selector.match?(html_node, selector, tree)
-        end
+        Enum.all?(pseudo_class.value, &(!Selector.match?(html_node, &1, tree)))
       "fl-contains" ->
         PseudoClass.match_contains?(tree, html_node, pseudo_class)
       unknown_pseudo_class ->

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -12,7 +12,7 @@ defmodule Floki.Selector do
             classes: [],
             attributes: [],
             namespace: nil,
-            pseudo_class: nil,
+            pseudo_classes: [],
             combinator: nil
 
   @doc false

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -97,6 +97,9 @@ defmodule Floki.Selector do
   end
 
   defp pseudo_class_match?(_html_node, nil, _tree), do: true
+  defp pseudo_class_match?(html_node, pseudo_classes, tree) when is_list(pseudo_classes) do
+    Enum.all?(pseudo_classes, &(pseudo_class_match?(html_node, &1, tree)))
+  end
   defp pseudo_class_match?(html_node, pseudo_class, tree) do
     case pseudo_class.name do
       "nth-child" ->

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -104,7 +104,10 @@ defmodule Floki.Selector do
       "first-child" ->
         PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: 1})
       "not" ->
-        !Selector.match?(html_node, pseudo_class.value, tree)
+        case pseudo_class.value do
+          selectors when is_list(selectors) -> Enum.all?(selectors, &(!Selector.match?(html_node, &1, tree)))
+          selector -> !Selector.match?(html_node, selector, tree)
+        end
       "fl-contains" ->
         PseudoClass.match_contains?(tree, html_node, pseudo_class)
       unknown_pseudo_class ->

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -41,7 +41,7 @@ defmodule Floki.SelectorParser do
 
     do_parse(t, %{selector | attributes: [result | selector.attributes]})
   end
-  defp do_parse([{:pseudo_not, _} | t], %Selector{pseudo_class: pseudo_classes}=selector) when is_list(pseudo_classes) do
+  defp do_parse([{:pseudo_not, _} | t], selector = %Selector{pseudo_class: pseudo_classes}) when is_list(pseudo_classes) do
     {t, pseudo_class} = do_parse_pseudo_not(t, %PseudoClass{name: "not"})
 
     do_parse(t, %{selector | pseudo_class: [pseudo_class | pseudo_classes]})

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -41,10 +41,15 @@ defmodule Floki.SelectorParser do
 
     do_parse(t, %{selector | attributes: [result | selector.attributes]})
   end
+  defp do_parse([{:pseudo_not, _} | t], %Selector{pseudo_class: pseudo_classes}=selector) when is_list(pseudo_classes) do
+    {t, pseudo_class} = do_parse_pseudo_not(t, %PseudoClass{name: "not"})
+
+    do_parse(t, %{selector | pseudo_class: [pseudo_class | pseudo_classes]})
+  end
   defp do_parse([{:pseudo_not, _} | t], selector) do
     {t, pseudo_class} = do_parse_pseudo_not(t, %PseudoClass{name: "not"})
 
-    do_parse(t, %{selector | pseudo_class: pseudo_class})
+    do_parse(t, %{selector | pseudo_class: [pseudo_class]})
   end
   defp do_parse([{:pseudo, _, pseudo_class} | t], selector) do
     do_parse(t, %{selector | pseudo_class: %PseudoClass{name: to_string(pseudo_class)}})

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -43,7 +43,7 @@ defmodule Floki.SelectorParser do
   end
   defp do_parse([{:pseudo_not, _} | t], selector) do
     {t, pseudo_not_class} = do_parse_pseudo_not(t, %PseudoClass{name: "not", value: []})
-    pseudo_classes = [pseudo_not_class | selector.pseudo_classes] |> Enum.reject(&is_nil(&1))
+    pseudo_classes = Enum.reject([pseudo_not_class | selector.pseudo_classes], &is_nil(&1))
     do_parse(t, %{selector | pseudo_classes: pseudo_classes})
   end
   defp do_parse([{:pseudo, _, pseudo_class} | t], selector) do

--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -70,23 +70,6 @@ defmodule Floki.SelectorParser do
     [pseudo_class | pseudo_classes] = selector.pseudo_classes
     do_parse(t, %{selector | pseudo_classes: [%{pseudo_class | value: to_string(pattern)} | pseudo_classes]})
   end
-  defp do_parse([{:pseudo_class_generic_value, _, value} | t], selector) do
-    s = case selector.pseudo_class do
-          %PseudoClass{name: "not"} ->
-            not_selector = parse(to_string(value))
-
-            if not_selector.combinator do
-              Logger.warn("Only simple selectors are allowed in :not() pseudo-class. Ignoring.")
-              selector
-            else
-              %{selector | pseudo_classes: %{selector.pseudo_class | value: not_selector}}
-            end
-          _ ->
-            selector
-        end
-
-    do_parse(t, s)
-  end
   defp do_parse([{:space, _} | t], selector) do
     {t, combinator} = consume_combinator(t, :descendant)
 

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -2,7 +2,7 @@ Definitions.
 
 IDENTIFIER = [-A-Za-z0-9_]+
 QUOTED = (\"[^"]*\"|\'[^']*\')
-PARENTESIS = \([^)]*\)
+PARENTHESES = \([^)]*\)
 INT = [0-9]+
 NOT = (n|N)(o|O)(t|T)
 ODD = (o|O)(d|D)(d|D)
@@ -18,13 +18,14 @@ Rules.
 {SYMBOL}                             : {token, {TokenChars, TokenLine}}.
 #{IDENTIFIER}                        : {token, {hash, TokenLine, tail(TokenChars)}}.
 \.{IDENTIFIER}                       : {token, {class, TokenLine, tail(TokenChars)}}.
-\:{NOT}\(                            : {token, {pseudo_not, TokenLine}}.
+\:{NOT}                              : {token, {pseudo_not, TokenLine}}.
 \:{IDENTIFIER}                       : {token, {pseudo, TokenLine, tail(TokenChars)}}.
 \({INT}\)                            : {token, {pseudo_class_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
 \({ODD}\)                            : {token, {pseudo_class_odd, TokenLine}}.
 \({EVEN}\)                           : {token, {pseudo_class_even, TokenLine}}.
 \({PSEUDO_PATT}\)                    : {token, {pseudo_class_pattern, TokenLine, remove_wrapper(TokenChars)}}.
 \({QUOTED}\)                         : {token, {pseudo_class_quoted, TokenLine, remove_wrapper(remove_wrapper(TokenChars))}}.
+{PARENTHESES}                        : {token, {pseudo_parentheses, TokenLine, remove_wrapper(TokenChars)}}.
 {W}*\)                               : {token, {close_parentesis, TokenLine}}.
 ~=                                   : {token, {includes, TokenLine}}.
 \|=                                  : {token, {dash_match, TokenLine}}.

--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -2,7 +2,7 @@ Definitions.
 
 IDENTIFIER = [-A-Za-z0-9_]+
 QUOTED = (\"[^"]*\"|\'[^']*\')
-PARENTHESES = \([^)]*\)
+PARENTESIS = \([^)]*\)
 INT = [0-9]+
 NOT = (n|N)(o|O)(t|T)
 ODD = (o|O)(d|D)(d|D)
@@ -18,14 +18,13 @@ Rules.
 {SYMBOL}                             : {token, {TokenChars, TokenLine}}.
 #{IDENTIFIER}                        : {token, {hash, TokenLine, tail(TokenChars)}}.
 \.{IDENTIFIER}                       : {token, {class, TokenLine, tail(TokenChars)}}.
-\:{NOT}                              : {token, {pseudo_not, TokenLine}}.
+\:{NOT}\(                            : {token, {pseudo_not, TokenLine}}.
 \:{IDENTIFIER}                       : {token, {pseudo, TokenLine, tail(TokenChars)}}.
 \({INT}\)                            : {token, {pseudo_class_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
 \({ODD}\)                            : {token, {pseudo_class_odd, TokenLine}}.
 \({EVEN}\)                           : {token, {pseudo_class_even, TokenLine}}.
 \({PSEUDO_PATT}\)                    : {token, {pseudo_class_pattern, TokenLine, remove_wrapper(TokenChars)}}.
 \({QUOTED}\)                         : {token, {pseudo_class_quoted, TokenLine, remove_wrapper(remove_wrapper(TokenChars))}}.
-{PARENTHESES}                        : {token, {pseudo_parentheses, TokenLine, remove_wrapper(TokenChars)}}.
 {W}*\)                               : {token, {close_parentesis, TokenLine}}.
 ~=                                   : {token, {includes, TokenLine}}.
 \|=                                  : {token, {dash_match, TokenLine}}.

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -133,27 +133,27 @@ defmodule Floki.SelectorParserTest do
     assert SelectorParser.parse("a.foo:not(.bar)") == %Selector{
       type: "a",
       classes: ["foo"],
-      pseudo_class: %PseudoClass{name: "not", value: [%Selector{classes: ["bar"]}]}
+      pseudo_class: [%PseudoClass{name: "not", value: [%Selector{classes: ["bar"]}]}]
     }
 
     assert SelectorParser.parse("a.foo:not(.bar, .baz)") == %Selector{
       type: "a",
       classes: ["foo"],
-      pseudo_class: %PseudoClass{name: "not", value: [%Selector{classes: ["baz"]}, %Selector{classes: ["bar"]}]}
+      pseudo_class: [%PseudoClass{name: "not", value: [%Selector{classes: ["baz"]}, %Selector{classes: ["bar"]}]}]
     }
 
     assert SelectorParser.parse("li:not(:nth-child(2)) a") == %Selector{
       type: "li",
-      pseudo_class: %PseudoClass{name: "not",
+      pseudo_class: [%PseudoClass{name: "not",
                                  value: [%Selector{pseudo_class: %PseudoClass{name: "nth-child",
-                                                  value: 2}}]},
+                                                  value: 2}}]}],
       combinator: %Combinator{match_type: :descendant, selector: %Selector{type: "a"}}
     }
 
     assert SelectorParser.parse("a.foo:not(.bar > .baz)") == %Selector{
       type: "a",
       classes: ["foo"],
-      pseudo_class: nil
+      pseudo_class: [nil]
     }
 
     assert capture_log(log_capturer("a.foo:not(.bar > .baz)")) =~

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -142,6 +142,15 @@ defmodule Floki.SelectorParserTest do
       pseudo_classes: [%PseudoClass{name: "not", value: [%Selector{classes: ["baz"]}, %Selector{classes: ["bar"]}]}]
     }
 
+    assert SelectorParser.parse("a.foo:not(.bar):not(.baz)") == %Selector{
+      type: "a",
+      classes: ["foo"],
+      pseudo_classes: [
+        %PseudoClass{name: "not", value: [%Selector{classes: ["baz"]}]},
+        %PseudoClass{name: "not", value: [%Selector{classes: ["bar"]}]}
+      ]
+    }
+
     assert SelectorParser.parse("li:not(:nth-child(2)) a") == %Selector{
       type: "li",
       pseudo_classes: [%PseudoClass{name: "not",

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -133,14 +133,20 @@ defmodule Floki.SelectorParserTest do
     assert SelectorParser.parse("a.foo:not(.bar)") == %Selector{
       type: "a",
       classes: ["foo"],
-      pseudo_class: %PseudoClass{name: "not", value: %Selector{classes: ["bar"]}}
+      pseudo_class: %PseudoClass{name: "not", value: [%Selector{classes: ["bar"]}]}
+    }
+
+    assert SelectorParser.parse("a.foo:not(.bar, .baz)") == %Selector{
+      type: "a",
+      classes: ["foo"],
+      pseudo_class: %PseudoClass{name: "not", value: [%Selector{classes: ["baz"]}, %Selector{classes: ["bar"]}]}
     }
 
     assert SelectorParser.parse("li:not(:nth-child(2)) a") == %Selector{
       type: "li",
       pseudo_class: %PseudoClass{name: "not",
-                                 value: %Selector{pseudo_class: %PseudoClass{name: "nth-child",
-                                                  value: 2}}},
+                                 value: [%Selector{pseudo_class: %PseudoClass{name: "nth-child",
+                                                  value: 2}}]},
       combinator: %Combinator{match_type: :descendant, selector: %Selector{type: "a"}}
     }
 

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -104,28 +104,28 @@ defmodule Floki.SelectorParserTest do
 
     assert SelectorParser.parse(tokens) == %Selector{
       type: "li",
-      pseudo_class: %PseudoClass{name: "nth-child", value: 2},
+      pseudo_classes: [%PseudoClass{name: "nth-child", value: 2}],
     }
 
     tokens = tokenize("tr:nth-child(odd)")
 
     assert SelectorParser.parse(tokens) == %Selector{
       type: "tr",
-      pseudo_class: %PseudoClass{name: "nth-child", value: "odd"}
+      pseudo_classes: [%PseudoClass{name: "nth-child", value: "odd"}]
     }
 
     tokens = tokenize("td:nth-child(even)")
 
     assert SelectorParser.parse(tokens) == %Selector{
       type: "td",
-      pseudo_class: %PseudoClass{name: "nth-child", value: "even"}
+      pseudo_classes: [%PseudoClass{name: "nth-child", value: "even"}]
     }
 
     tokens = tokenize("div:nth-child(-n+3)")
 
     assert SelectorParser.parse(tokens) == %Selector{
       type: "div",
-      pseudo_class: %PseudoClass{name: "nth-child", value: "-n+3"}
+      pseudo_classes: [%PseudoClass{name: "nth-child", value: "-n+3"}]
     }
   end
 
@@ -133,27 +133,27 @@ defmodule Floki.SelectorParserTest do
     assert SelectorParser.parse("a.foo:not(.bar)") == %Selector{
       type: "a",
       classes: ["foo"],
-      pseudo_class: [%PseudoClass{name: "not", value: [%Selector{classes: ["bar"]}]}]
+      pseudo_classes: [%PseudoClass{name: "not", value: [%Selector{classes: ["bar"]}]}]
     }
 
     assert SelectorParser.parse("a.foo:not(.bar, .baz)") == %Selector{
       type: "a",
       classes: ["foo"],
-      pseudo_class: [%PseudoClass{name: "not", value: [%Selector{classes: ["baz"]}, %Selector{classes: ["bar"]}]}]
+      pseudo_classes: [%PseudoClass{name: "not", value: [%Selector{classes: ["baz"]}, %Selector{classes: ["bar"]}]}]
     }
 
     assert SelectorParser.parse("li:not(:nth-child(2)) a") == %Selector{
       type: "li",
-      pseudo_class: [%PseudoClass{name: "not",
-                                 value: [%Selector{pseudo_class: %PseudoClass{name: "nth-child",
-                                                  value: 2}}]}],
+      pseudo_classes: [%PseudoClass{name: "not",
+                                 value: [%Selector{pseudo_classes: [%PseudoClass{name: "nth-child",
+                                                  value: 2}]}]}],
       combinator: %Combinator{match_type: :descendant, selector: %Selector{type: "a"}}
     }
 
     assert SelectorParser.parse("a.foo:not(.bar > .baz)") == %Selector{
       type: "a",
       classes: ["foo"],
-      pseudo_class: [nil]
+      pseudo_classes: []
     }
 
     assert capture_log(log_capturer("a.foo:not(.bar > .baz)")) =~

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -552,22 +552,23 @@ defmodule FlokiTest do
           <a class="link foo">A foo</a>
           <a class="link bar">A bar</a>
           <a class="link baz">A baz</a>
+          <a class="link bin">A bin</a>
         </div>
       </body>
     </html>
     """
-    first_result = Floki.find(html, "a.link:not(.bar)")
-    second_result = Floki.find(html, "a.link:not(.bar, .baz)")
-    third_result = Floki.find(html, "a.link:not(.bar,.baz)")
+    first_result = Floki.find(html, "a.link:not(.bar, .baz)")
+    second_result = Floki.find(html, "a.link:not(.bar,.baz)")
+    third_result = Floki.find(html, "a.link:not(.bar):not(.baz)")
+    fourth_result = Floki.find(html, "a.link:not(.bar, .bin):not(.baz)")
 
-    expected_result = [
-      {"a", [{"class", "link foo"}], ["A foo"]},
-      {"a", [{"class", "link baz"}], ["A baz"]}
-    ]
+    foo_match = {"a", [{"class", "link foo"}], ["A foo"]}
+    bin_match = {"a", [{"class", "link bin"}], ["A bin"]}
 
-    assert first_result == expected_result
-    assert second_result == [{"a", [{"class", "link foo"}], ["A foo"]}]
-    assert third_result == [{"a", [{"class", "link foo"}], ["A foo"]}]
+    assert first_result == [foo_match, bin_match]
+    assert second_result == [foo_match, bin_match]
+    assert third_result == [foo_match, bin_match]
+    assert fourth_result == [foo_match]
   end
 
   test "pseudo-class selector only" do

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -544,6 +544,32 @@ defmodule FlokiTest do
     assert third_result == expected_result
   end
 
+  test "not pseudo-class with multiple selectors" do
+    html = """
+    <html>
+      <body>
+        <div id="links">
+          <a class="link foo">A foo</a>
+          <a class="link bar">A bar</a>
+          <a class="link baz">A baz</a>
+        </div>
+      </body>
+    </html>
+    """
+    first_result = Floki.find(html, "a.link:not(.bar)")
+    second_result = Floki.find(html, "a.link:not(.bar, .baz)")
+    third_result = Floki.find(html, "a.link:not(.bar,.baz)")
+
+    expected_result = [
+      {"a", [{"class", "link foo"}], ["A foo"]},
+      {"a", [{"class", "link baz"}], ["A baz"]}
+    ]
+
+    assert first_result == expected_result
+    assert second_result == [{"a", [{"class", "link foo"}], ["A foo"]}]
+    assert third_result == [{"a", [{"class", "link foo"}], ["A foo"]}]
+  end
+
   test "pseudo-class selector only" do
     expected = [
       {"channel", [], [{"title", [], ["A podcast"]}, {"link", [], ["www.foo.bar.com"]}]},


### PR DESCRIPTION
While trying to utilize the new pseudo `not` selector, I was trying to do a selection with multiple _or_ selectors in the `not` pseudo class. i.e. `a.link:not(.bar, [style=baz])`

However, `finder.ex` was splitting the string at `,` which broke up all subsequent token parsing. So I went ahead and mocked this up to support this use-case.

Happy to change what is needed to meet any style preference or design that's not currently met. Let me know what you think.

@philss @mmmries 