### PR TITLE
Ignore style tag content in Floki.text/1

### DIFF
--- a/lib/floki/deep_text.ex
+++ b/lib/floki/deep_text.ex
@@ -21,6 +21,7 @@ defmodule Floki.DeepText do
   end
   defp get_text({:comment, _}, acc, _), do: acc
   defp get_text({"br", _, _}, acc, _), do: acc <> "\n"
+  defp get_text({"style", _, _}, acc, _), do: acc
   defp get_text({_, _, nodes}, acc, sep) do
     get_text(nodes, acc, sep)
   end

--- a/test/floki/deep_text_test.exs
+++ b/test/floki/deep_text_test.exs
@@ -28,6 +28,15 @@ defmodule Floki.DeepTextTest do
      assert Floki.DeepText.get(nodes) == "This is a text that is divided into tiny pieces. It keeps growing... And ends."
   end
 
+  test "ignores text inside style tag" do
+    nodes =
+      [{"body", [],
+          [{"style", [], ".my-class{ text-algn: center'}"},
+           {"p", [], "Hello world."}]}]
+
+     assert Floki.DeepText.get(nodes) == "Hello world."
+  end
+
   test "text from a list of deep nodes with a separator" do
     nodes =
       [{"div", [],


### PR DESCRIPTION
Currently if there is a `<style>` tag in the body of the html, its content is included when calling `Floki.text/1`. This omits the content of the style tag from the text output.