### PR TITLE
fixed crash caused by xml declaration inside body

### DIFF
--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -99,14 +99,18 @@ defmodule Floki.HTMLTree do
   defp build_tree(tree, [], _, []), do: tree
   defp build_tree(tree, [{tag, attrs, child_children} | children], parent_id, stack) do
     new_id = IDSeeder.seed(tree.node_ids)
-    new_node = %HTMLNode{type: tag,
-                         attributes: attrs,
-                         node_id: new_id,
-                         parent_node_id: parent_id}
+    nodes = if tag != :pi do
+      new_node = %HTMLNode{type: tag,
+                           attributes: attrs,
+                           node_id: new_id,
+                           parent_node_id: parent_id}
 
-    nodes = put_new_node(tree.nodes, new_node)
+      put_new_node(tree.nodes, new_node)
+    else
+      tree.nodes
+    end
 
-   build_tree(%{tree | nodes: nodes, node_ids: [new_id | tree.node_ids]},
+    build_tree(%{tree | nodes: nodes, node_ids: [new_id | tree.node_ids]},
               child_children, new_id, [{parent_id, children} | stack])
   end
   defp build_tree(tree, [{:comment, comment} | children], parent_id, stack) do

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -97,18 +97,16 @@ defmodule Floki.HTMLTree do
   defp get_ids_for_delete_stack(_), do: []
 
   defp build_tree(tree, [], _, []), do: tree
+  defp build_tree(tree, [{:pi, _, _} | children], parent_id, stack), do: build_tree(tree, children, parent_id, stack)
   defp build_tree(tree, [{tag, attrs, child_children} | children], parent_id, stack) do
     new_id = IDSeeder.seed(tree.node_ids)
-    nodes = if tag != :pi do
-      new_node = %HTMLNode{type: tag,
-                           attributes: attrs,
-                           node_id: new_id,
-                           parent_node_id: parent_id}
 
-      put_new_node(tree.nodes, new_node)
-    else
-      tree.nodes
-    end
+    new_node = %HTMLNode{type: tag,
+                         attributes: attrs,
+                         node_id: new_id,
+                         parent_node_id: parent_id}
+
+    nodes = put_new_node(tree.nodes, new_node)
 
     build_tree(%{tree | nodes: nodes, node_ids: [new_id | tree.node_ids]},
               child_children, new_id, [{parent_id, children} | stack])

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
-  "credo": {:hex, :credo, "0.7.2", "850463f126c09227994967fdcf8b8ad7684ab220f7727c00bcafc0ac37bd3660", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.7.2", "850463f126c09227994967fdcf8b8ad7684ab220f7727c00bcafc0ac37bd3660", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -761,4 +761,20 @@ defmodule FlokiTest do
     [{tag_name, _, _}] = Floki.find(@html_with_wrong_angles_encoding, "span")
     assert tag_name == "span"
   end
+
+  test "html with xml definition tag in it" do
+    html = """
+      <!DOCTYPE html>
+      <html>
+      <head>
+      </head>
+      <body>
+        <div class="text">test</div>
+        <?xml version="1.0" encoding="utf-8"?>
+      </div>
+      </body>
+      </html>
+    """
+    assert Floki.find(html, ".text") == [{"div", [{"class", "text"}], ["test"]}]
+  end
 end


### PR DESCRIPTION
I was trying to parse a page that for some unknown reason has a xml declaration tag lost inside the body tag that caused Floki to crash.
I added a test for that edge case and a quick fix that just ignores it.