### PR TITLE
Handle attribute selectors in :not()

### DIFF
--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -29,6 +29,7 @@ defmodule Floki.SelectorParser do
   end
 
   defp do_parse([], selector), do: {selector, []}
+  defp do_parse([{:close_parentesis, _} | t], selector), do: {selector, t}
   defp do_parse([{:comma, _}| t], selector), do: {selector, t}
   defp do_parse([{:identifier, _, namespace}, {:namespace_pipe, _} | t], selector) do
     do_parse(t, %{selector | namespace: to_string(namespace)})
@@ -147,6 +148,9 @@ defmodule Floki.SelectorParser do
     {remaining_tokens, %{combinator | selector: selector}}
   end
 
+  defp do_parse_pseudo_not([], pseudo_class) do
+    {[], pseudo_class}
+  end
   defp do_parse_pseudo_not([{:close_parentesis, _} | t], pseudo_class) do
     {t, pseudo_class}
   end
@@ -155,6 +159,10 @@ defmodule Floki.SelectorParser do
   end
   defp do_parse_pseudo_not(tokens, pseudo_class) do
     do_parse_pseudo_not(tokens, %Selector{}, pseudo_class)
+  end
+  defp do_parse_pseudo_not([], pseudo_not_selector, pseudo_class) do
+    pseudo_class = update_pseudo_not_value(pseudo_class, pseudo_not_selector)
+    {[], pseudo_class}
   end
   defp do_parse_pseudo_not([{:close_parentesis, _} | t], pseudo_not_selector, pseudo_class) do
     pseudo_class = update_pseudo_not_value(pseudo_class, pseudo_not_selector)
@@ -166,6 +174,11 @@ defmodule Floki.SelectorParser do
   end
   defp do_parse_pseudo_not([{:space, _} | t], pseudo_not_selector, pseudo_class) do
     do_parse_pseudo_not(t, pseudo_not_selector, pseudo_class)
+  end
+  defp do_parse_pseudo_not([{'[', _} | _t]=tokens, pseudo_not_selector, pseudo_class) do
+    {pseudo_not_selector, remaining_tokens} = do_parse(tokens, pseudo_not_selector)
+    pseudo_class = update_pseudo_not_value(pseudo_class, pseudo_not_selector)
+    do_parse_pseudo_not(remaining_tokens, pseudo_class)
   end
   defp do_parse_pseudo_not([next_token | t], pseudo_not_selector, pseudo_class) do
     {pseudo_not_selector, _} = do_parse([next_token], pseudo_not_selector)

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.7.4", "0c33bcce4d574ce6df163cbc7d1ecb22de65713184355bd3be81cc4ab0ecaafa", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
-  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], [], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+  "credo": {:hex, :credo, "0.7.4", "0c33bcce4d574ce6df163cbc7d1ecb22de65713184355bd3be81cc4ab0ecaafa", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
+  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -205,6 +205,37 @@ defmodule Floki.SelectorParserTest do
       }
     ]
 
+    assert SelectorParser.parse("a.foo:not([style*=crazy])") == [
+      %Selector{
+        attributes: [],
+        classes: ["foo"],
+        pseudo_classes: [
+          %PseudoClass{
+            name: "not",
+            value: [%Selector{attributes: [%Floki.AttributeSelector{attribute: "style", match_type: :substring_match, value: "crazy"}], classes: [], pseudo_classes: []}]
+          }
+        ],
+        type: "a"
+      }
+    ]
+
+    assert SelectorParser.parse("a.foo:not([style*=crazy], .bar)") == [
+      %Selector{
+        attributes: [],
+        classes: ["foo"],
+        pseudo_classes: [
+          %PseudoClass{
+            name: "not",
+            value: [
+              %Selector{attributes: [], classes: ["bar"], pseudo_classes: []},
+              %Selector{attributes: [%Floki.AttributeSelector{attribute: "style", match_type: :substring_match, value: "crazy"}], classes: [], pseudo_classes: []}
+            ]
+          }
+        ],
+        type: "a"
+      }
+    ]
+
     assert capture_log(log_capturer("a.foo:not(.bar > .baz)")) =~
             "module=Floki.SelectorParser  Only simple selectors are allowed in :not() pseudo-class. Ignoring."
   end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -545,7 +545,7 @@ defmodule FlokiTest do
       <body>
         <div id="links">
           <a class="link foo">A foo</a>
-          <a class="link bar">A bar</a>
+          <a class="link bar" style="crazyColor">A bar</a>
           <a class="link baz">A baz</a>
         </div>
       </body>
@@ -554,6 +554,7 @@ defmodule FlokiTest do
     first_result = Floki.find(html, "a.link:not(.bar)")
     second_result = Floki.find(html, "div#links > a.link:not(.bar)")
     third_result = Floki.find(html, "a.link:not(:nth-child(2))")
+    fourth_result = Floki.find(html, "a.link:not([style*=crazy])")
 
     expected_result = [
       {"a", [{"class", "link foo"}], ["A foo"]},
@@ -563,6 +564,7 @@ defmodule FlokiTest do
     assert first_result == expected_result
     assert first_result == second_result
     assert third_result == expected_result
+    assert fourth_result == expected_result
   end
 
   test "not pseudo-class with multiple selectors" do
@@ -571,7 +573,7 @@ defmodule FlokiTest do
       <body>
         <div id="links">
           <a class="link foo">A foo</a>
-          <a class="link bar">A bar</a>
+          <a class="link bar" style="crazyColor">A bar</a>
           <a class="link baz">A baz</a>
           <a class="link bin">A bin</a>
         </div>
@@ -582,6 +584,7 @@ defmodule FlokiTest do
     second_result = Floki.find(html, "a.link:not(.bar,.baz)")
     third_result = Floki.find(html, "a.link:not(.bar):not(.baz)")
     fourth_result = Floki.find(html, "a.link:not(.bar, .bin):not(.baz)")
+    fifth_result = Floki.find(html, "a.link:not([style*=crazy], .bin):not(.baz)")
 
     foo_match = {"a", [{"class", "link foo"}], ["A foo"]}
     bin_match = {"a", [{"class", "link bin"}], ["A bin"]}
@@ -590,6 +593,7 @@ defmodule FlokiTest do
     assert second_result == [foo_match, bin_match]
     assert third_result == [foo_match, bin_match]
     assert fourth_result == [foo_match]
+    assert fifth_result == [foo_match]
   end
 
   test "pseudo-class selector only" do


### PR DESCRIPTION
Simple update to allow pseudo `:not()` selects to handle attribute selectors within the parenthesis:
`a.link:not([class*=baz])` etc etc

@philss 

(ps. I'm not sure if you want mix.lock, but it looks like some deps were updated it so I included. Can drop easily if needed)