### PR TITLE
Return selector after consuming combinator

### DIFF
--- a/lib/floki/selector_parser.ex
+++ b/lib/floki/selector_parser.ex
@@ -80,24 +80,24 @@ defmodule Floki.SelectorParser do
     do_parse(t, %{selector | pseudo_classes: [%{pseudo_class | value: to_string(pattern)} | pseudo_classes]})
   end
   defp do_parse([{:space, _} | t], selector) do
-    {t, combinator} = consume_combinator(t, :descendant)
+    {remaining_tokens, combinator} = consume_combinator(t, :descendant)
 
-    do_parse(t, %{selector | combinator: combinator})
+    {%{selector | combinator: combinator}, remaining_tokens}
   end
   defp do_parse([{:greater, _} | t], selector) do
-    {t, combinator} = consume_combinator(t, :child)
+    {remaining_tokens, combinator} = consume_combinator(t, :child)
 
-    do_parse(t, %{selector | combinator: combinator})
+    {%{selector | combinator: combinator}, remaining_tokens}
   end
   defp do_parse([{:plus, _} | t], selector) do
-    {t, combinator} = consume_combinator(t, :sibling)
+    {remaining_tokens, combinator} = consume_combinator(t, :sibling)
 
-    do_parse(t, %{selector | combinator: combinator})
+    {%{selector | combinator: combinator}, remaining_tokens}
   end
   defp do_parse([{:tilde, _} | t], selector) do
-    {t, combinator} = consume_combinator(t, :general_sibling)
+    {remaining_tokens, combinator} = consume_combinator(t, :general_sibling)
 
-    do_parse(t, %{selector | combinator: combinator})
+    {%{selector | combinator: combinator}, remaining_tokens}
   end
   defp do_parse([{:unknown, _, unknown} | t], selector) do
     Logger.warn("Unknown token #{inspect unknown}. Ignoring.")

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -31,6 +31,21 @@ defmodule Floki.SelectorParserTest do
     ]
   end
 
+  # test "multiple selectors with combinators" do
+  #   tokens = tokenize("ol > .foo, ul a[class=bar], a + .baz")
+  #
+  #   assert SelectorParser.parse(tokens) == [
+  #     %Selector{
+  #       type: "ol",
+  #       combinator: %Combinator{match_type: :child, selector: %Selector{attributes: [], classes: ["foo"], pseudo_classes: []}}
+  #     },
+  #     %Selector{
+  #       type: "ul",
+  #       combinator: %Combinator{match_type: :descendant, selector: %Selector{attributes: [%AttributeSelector{attribute: "class", match_type: :equal, value: "bar"}], classes: [], pseudo_classes: [], type: "a"}}
+  #     }
+  #   ]
+  # end
+
   test "type with classes" do
     tokens = tokenize("a.link.button")
 
@@ -92,6 +107,33 @@ defmodule Floki.SelectorParserTest do
     ]
   end
 
+  test "multiple descendant selectors" do
+    tokens = tokenize("a b.foo c, ul a[class=bar]")
+
+    assert SelectorParser.parse(tokens) == [
+      %Selector{
+        type: "a",
+        combinator: %Combinator{
+          match_type: :descendant,
+          selector: %Selector{type: "b",
+                              classes: ["foo"],
+                              combinator: %Combinator{match_type: :descendant,
+                                                      selector: %Selector{type: "c"}}}
+        }
+      },
+      %Selector{
+        type: "ul",
+        combinator: %Combinator{
+          match_type: :descendant,
+          selector: %Selector{attributes: [%AttributeSelector{attribute: "class", match_type: :equal, value: "bar"}],
+                              classes: [],
+                              pseudo_classes: [],
+                              type: "a"}
+        }
+      }
+    ]
+  end
+
   test "child selector" do
     tokens = tokenize("a > b")
 
@@ -102,6 +144,24 @@ defmodule Floki.SelectorParserTest do
           match_type: :child,
           selector: %Selector{type: "b"}
         }
+      }
+    ]
+  end
+
+  test "multiple child selectors" do
+    tokens = tokenize("a > b, ol > .foo")
+
+    assert SelectorParser.parse(tokens) == [
+      %Selector{
+        type: "a",
+        combinator: %Combinator{
+          match_type: :child,
+          selector: %Selector{type: "b"}
+        }
+      },
+      %Selector{
+        type: "ol",
+        combinator: %Combinator{match_type: :child, selector: %Selector{attributes: [], classes: ["foo"], pseudo_classes: []}}
       }
     ]
   end

--- a/test/floki/selector_parser_test.exs
+++ b/test/floki/selector_parser_test.exs
@@ -31,21 +31,6 @@ defmodule Floki.SelectorParserTest do
     ]
   end
 
-  # test "multiple selectors with combinators" do
-  #   tokens = tokenize("ol > .foo, ul a[class=bar], a + .baz")
-  #
-  #   assert SelectorParser.parse(tokens) == [
-  #     %Selector{
-  #       type: "ol",
-  #       combinator: %Combinator{match_type: :child, selector: %Selector{attributes: [], classes: ["foo"], pseudo_classes: []}}
-  #     },
-  #     %Selector{
-  #       type: "ul",
-  #       combinator: %Combinator{match_type: :descendant, selector: %Selector{attributes: [%AttributeSelector{attribute: "class", match_type: :equal, value: "bar"}], classes: [], pseudo_classes: [], type: "a"}}
-  #     }
-  #   ]
-  # end
-
   test "type with classes" do
     tokens = tokenize("a.link.button")
 


### PR DESCRIPTION
Since [the change to parse all tokens, a selector is returned when encountering a `:comma` token](https://github.com/philss/floki/pull/106/files#diff-7f26dd84090995cad0112f38a801b18bR32). 

When we `consume_combinators`, that calls `do_parse` which gets a selector and continues on parsing tokens. However, the selector is returned as a result of matching `:comma` token and removes it from the remaining tokens. So when parsing continues after `consume_combinator`, it continues parsing the previous selector instead of starting a new one.

This changes so `consume_combinator` functions return a selector tuple since they will get a fully completed selector after parsing.

```elixir
# before the change
iex> "a b.foo c, ul a[class=bar]" |> Floki.SelectorTokenizer.tokenize |> Floki.SelectorParser.parse |> length
1
iex> "a b.foo c, ul a[class=bar]" |> Floki.SelectorTokenizer.tokenize |> Floki.SelectorParser.parse
[%Floki.Selector{attributes: [], classes: [],
  combinator: %Floki.Combinator{match_type: :descendant,
   selector: %Floki.Selector{attributes: [], classes: ["foo"],
    combinator: %Floki.Combinator{match_type: :descendant,
     selector: %Floki.Selector{attributes: [%Floki.AttributeSelector{attribute: "class",
        match_type: :equal, value: "bar"}], classes: [], combinator: nil,
      id: nil, namespace: nil, pseudo_classes: [], type: "a"}}, id: nil,
    namespace: nil, pseudo_classes: [], type: "ul"}}, id: nil, namespace: nil,
  pseudo_classes: [], type: "a"}]

# With proposed changes
iex> "a b.foo c, ul a[class=bar]" |> Floki.SelectorTokenizer.tokenize |> Floki.SelectorParser.parse |> length
2
iex> "a b.foo c, ul a[class=bar]" |> Floki.SelectorTokenizer.tokenize |> Floki.SelectorParser.parse
[%Floki.Selector{attributes: [], classes: [],
  combinator: %Floki.Combinator{match_type: :descendant,
   selector: %Floki.Selector{attributes: [], classes: ["foo"],
    combinator: %Floki.Combinator{match_type: :descendant,
     selector: %Floki.Selector{attributes: [], classes: [], combinator: nil,
      id: nil, namespace: nil, pseudo_classes: [], type: "c"}}, id: nil,
    namespace: nil, pseudo_classes: [], type: "b"}}, id: nil, namespace: nil,
  pseudo_classes: [], type: "a"},
 %Floki.Selector{attributes: [], classes: [],
  combinator: %Floki.Combinator{match_type: :descendant,
   selector: %Floki.Selector{attributes: [%Floki.AttributeSelector{attribute: "class",
      match_type: :equal, value: "bar"}], classes: [], combinator: nil, id: nil,
    namespace: nil, pseudo_classes: [], type: "a"}}, id: nil, namespace: nil,
  pseudo_classes: [], type: "ul"}]
```

I _think_ this covers all the missing cases, but would definitely love close 👀 and any suggestions you believe may still need to be tested.