### PR TITLE
Fix converting html_tree to raw html when it has xml prefix

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -93,6 +93,9 @@ defmodule Floki do
   defp raw_html(tuple, html) when is_tuple(tuple), do: raw_html([tuple], html)
   defp raw_html([string|tail], html) when is_binary(string), do: raw_html(tail, html <> string)
   defp raw_html([{:comment, comment}|tail], html), do: raw_html(tail, html <> "<!--#{comment}-->")
+  defp raw_html([{:pi, "xml", attrs} |tail], html) do
+    raw_html(tail, html <> "<?xml " <> tag_attrs(attrs) <> "?>")
+  end
   defp raw_html([{type, attrs, children}|tail], html) do
     raw_html(tail, html <> tag_for(type, tag_attrs(attrs), children))
   end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -799,6 +799,11 @@ defmodule FlokiTest do
     assert tag_name == "a"
   end
 
+  test "we can produce raw_html if it has an xml version prefix" do
+    processed_html = @html_with_xml_prefix |> Floki.parse |> Floki.raw_html
+    assert String.starts_with?(processed_html, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+  end
+
   test "change tag attributes" do
     html = """
     <a class="change" href=\"http://not.url/changethis/\">link</a>


### PR DESCRIPTION
Previously it was failing with:
(Protocol.UndefinedError) protocol Enumerable not implemented for "xml"