### PR TITLE
Add implementation of String.Chars protocol to Selector

### DIFF
--- a/lib/floki/attribute_selector.ex
+++ b/lib/floki/attribute_selector.ex
@@ -8,6 +8,24 @@ defmodule Floki.AttributeSelector do
 
   defstruct match_type: nil, attribute: nil, value: nil
 
+  defimpl String.Chars do
+    def to_string(selector) do
+      "[#{selector.attribute}#{type(selector.match_type)}'#{selector.value}']"
+    end
+
+    defp type(match_type) do
+      case match_type do
+        :equal -> "="
+        :includes -> "~="
+        :dash_match -> "|="
+        :prefix_match -> "^="
+        :sufix_match -> "$="
+        :substring_match -> "*="
+        _ -> ""
+      end
+    end
+  end
+
   # Returns if attributes of a node matches with a given attribute selector.
   def match?(attributes, s = %AttributeSelector{match_type: nil, value: nil}) do
     attribute_present?(s.attribute, attributes)

--- a/lib/floki/combinator.ex
+++ b/lib/floki/combinator.ex
@@ -15,4 +15,18 @@ defmodule Floki.Combinator do
   #   e.g.: "a ~ b"
 
   defstruct match_type: nil, selector: nil
+
+  defimpl String.Chars do
+    def to_string(combinator) do
+      match_type = case combinator.match_type do
+        :descendant -> " "
+        :child -> " > "
+        :adjacent_sibling -> " + "
+        :general_sibling -> " ~ "
+        _ -> ""
+      end
+
+      "#{match_type}#{combinator.selector}"
+    end
+  end
 end

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -15,6 +15,29 @@ defmodule Floki.Selector do
             pseudo_classes: [],
             combinator: nil
 
+  defimpl String.Chars do
+    def to_string(selector) do
+      Enum.join([
+        namespace(selector),
+        selector.type,
+        id(selector),
+        classes(selector),
+        Enum.join(selector.attributes),
+        Enum.join(selector.pseudo_classes),
+        selector.combinator
+      ])
+    end
+
+    defp namespace(%{namespace: nil}), do: ""
+    defp namespace(%{namespace: ns}), do: "#{ns} | "
+
+    defp id(%{id: nil}), do: ""
+    defp id(%{id: id}), do: "##{id}"
+
+    defp classes(%{classes: []}), do: ""
+    defp classes(%{classes: classes}), do: ".#{Enum.join(classes, ".")}"
+  end
+
   @doc false
 
   # Returns if a given node matches with a given selector.

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -8,6 +8,18 @@ defmodule Floki.Selector.PseudoClass do
 
   alias Floki.HTMLTree.{HTMLNode, Text}
 
+  defimpl String.Chars do
+    def to_string(%{name: name, value: nil}) do
+      ":#{name}"
+    end
+    def to_string(%{name: name, value: selectors}) when is_list(selectors) do
+      ":#{name}(#{Enum.join(selectors)})"
+    end
+    def to_string(pseudo_class) do
+      ":#{pseudo_class.name}(#{pseudo_class.value})"
+    end
+  end
+
   def match_nth_child?(_, %HTMLNode{parent_node_id: nil}, _), do: false
   def match_nth_child?(tree, html_node, %__MODULE__{value: position}) when is_integer(position) do
     node_position(tree, html_node) == position

--- a/test/floki/selector_test.exs
+++ b/test/floki/selector_test.exs
@@ -1,0 +1,28 @@
+defmodule Floki.SelectorTest do
+  use ExUnit.Case, async: true
+
+  alias Floki.{AttributeSelector, Selector, Combinator}
+  alias Selector.PseudoClass
+
+  test "to_string/1 (String.Chars protocol)" do
+    attribute1 = %AttributeSelector{match_type: :equal, attribute: "href", value: "#home"}
+    pseudo_class1 = %PseudoClass{name: "nth-child", value: 7}
+
+    selector = %Selector{
+      namespace: "ns",
+      id: "main",
+      type: "div",
+      classes: ["foo", "bar"],
+      attributes: [attribute1],
+      pseudo_classes: [pseudo_class1],
+      combinator: %Combinator{
+        match_type: :adjacent_sibling,
+        selector: %Selector{type: "a"}
+      }
+    }
+    assert to_string(selector) == "ns | div#main.foo.bar[href='#home']:nth-child(7) + a"
+
+    pseudo_class2 = %PseudoClass{name: "first"}
+    assert to_string(%Selector{type: "li", pseudo_classes: [pseudo_class2]}) == "li:first"
+  end
+end


### PR DESCRIPTION
This is needed in order to make easier to understand what a
`Floki.Selector` represents as CSS selector.