### PR TITLE
Organize modules related to `Selector`

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -6,9 +6,8 @@ defmodule Floki.Finder do
   # The finder engine traverse the HTML tree searching for nodes matching
   # selectors.
 
-  alias Floki.{Combinator, Selector, SelectorParser, SelectorTokenizer}
-  alias Floki.HTMLTree
-  alias Floki.HTMLTree.HTMLNode
+  alias Floki.{HTMLTree, Selector}
+  alias HTMLTree.HTMLNode
 
   @type html_tree :: tuple | list
   @type selector :: binary | %Selector{} | [%Selector{}]
@@ -58,8 +57,8 @@ defmodule Floki.Finder do
 
   defp get_selectors(selector_as_string) do
     selector_as_string
-    |> SelectorTokenizer.tokenize()
-    |> SelectorParser.parse()
+    |> Selector.Tokenizer.tokenize()
+    |> Selector.Parser.parse()
   end
 
   defp get_matches_for_selectors(tree, html_node, selectors) do
@@ -89,7 +88,7 @@ defmodule Floki.Finder do
   # So the scope of one combinator is the stack (or acc) or the parent one.
   defp traverse_with(_, _, []), do: []
   defp traverse_with(nil, _, results), do: results
-  defp traverse_with(%Combinator{match_type: :child, selector: s}, tree, stack) do
+  defp traverse_with(%Selector.Combinator{match_type: :child, selector: s}, tree, stack) do
     results =
       Enum.flat_map(stack, fn(html_node) ->
         nodes = html_node.children_nodes_ids
@@ -101,7 +100,7 @@ defmodule Floki.Finder do
 
     traverse_with(s.combinator, tree, results)
   end
-  defp traverse_with(%Combinator{match_type: :sibling, selector: s}, tree, stack) do
+  defp traverse_with(%Selector.Combinator{match_type: :sibling, selector: s}, tree, stack) do
     results =
       Enum.flat_map(stack, fn(html_node) ->
         # It treats sibling as list to easily ignores those that didn't match
@@ -117,7 +116,7 @@ defmodule Floki.Finder do
 
     traverse_with(s.combinator, tree, results)
   end
-  defp traverse_with(%Combinator{match_type: :general_sibling, selector: s}, tree, stack) do
+  defp traverse_with(%Selector.Combinator{match_type: :general_sibling, selector: s}, tree, stack) do
     results =
       Enum.flat_map(stack, fn(html_node) ->
         sibling_ids = get_siblings(html_node, tree)
@@ -130,7 +129,7 @@ defmodule Floki.Finder do
 
     traverse_with(s.combinator, tree, results)
   end
-  defp traverse_with(%Combinator{match_type: :descendant, selector: s}, tree, stack) do
+  defp traverse_with(%Selector.Combinator{match_type: :descendant, selector: s}, tree, stack) do
     results =
       Enum.flat_map(stack, fn(html_node) ->
         ids_to_match = get_descendant_ids(html_node.node_id, tree)

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -3,9 +3,9 @@ defmodule Floki.Selector do
   @moduledoc false
   # Represents a CSS selector. It also have functions to match nodes with a given selector.
 
-  alias Floki.{Selector, AttributeSelector}
-  alias Floki.Selector.PseudoClass
-  alias Floki.HTMLTree.{HTMLNode, Text, Comment}
+  alias Floki.{Selector, HTMLTree}
+  alias Selector.{AttributeSelector, PseudoClass}
+  alias HTMLTree.{HTMLNode, Text, Comment}
 
   defstruct id: nil,
             type: nil,

--- a/lib/floki/selector/attribute_selector.ex
+++ b/lib/floki/selector/attribute_selector.ex
@@ -1,10 +1,10 @@
-defmodule Floki.AttributeSelector do
+defmodule Floki.Selector.AttributeSelector do
   @moduledoc false
 
   # It is very similar to the `Selector` module, but is specialized in attributes
   # and attribute selectors.
 
-  alias Floki.AttributeSelector
+  alias Floki.Selector.AttributeSelector
 
   defstruct match_type: nil, attribute: nil, value: nil
 

--- a/lib/floki/selector/combinator.ex
+++ b/lib/floki/selector/combinator.ex
@@ -1,4 +1,4 @@
-defmodule Floki.Combinator do
+defmodule Floki.Selector.Combinator do
   @moduledoc false
 
   # Represents the conjunction of a combinator with its selector.

--- a/lib/floki/selector/parser.ex
+++ b/lib/floki/selector/parser.ex
@@ -1,18 +1,18 @@
-defmodule Floki.SelectorParser do
+defmodule Floki.Selector.Parser do
   require Logger
 
   @moduledoc false
-  # Parses a list of tokens returned from `SelectorTokenizer` and transfor into a `Selector`.
+  # Parses a list of tokens returned from `Tokenizer` and transfor into a `Selector`.
 
-  alias Floki.{Selector, SelectorTokenizer, AttributeSelector, Combinator}
-  alias Floki.Selector.PseudoClass
+  alias Floki.Selector
+  alias Selector.{Tokenizer, PseudoClass, AttributeSelector, Combinator}
 
   @attr_match_types [:equal, :dash_match, :includes, :prefix_match, :sufix_match, :substring_match]
 
   # Returns a list of `Selector` structs with the parsed selectors.
 
   def parse(selector) when is_binary(selector) do
-    token_list = SelectorTokenizer.tokenize(selector)
+    token_list = Tokenizer.tokenize(selector)
     parse(token_list)
   end
   def parse(tokens) do

--- a/lib/floki/selector/tokenizer.ex
+++ b/lib/floki/selector/tokenizer.ex
@@ -1,4 +1,4 @@
-defmodule Floki.SelectorTokenizer do
+defmodule Floki.Selector.Tokenizer do
   @moduledoc false
 
   # It decodes a given selector and returns the tokens that represents it.

--- a/test/floki/selector/tokenizer_test.exs
+++ b/test/floki/selector/tokenizer_test.exs
@@ -1,9 +1,9 @@
-defmodule Floki.SelectorTokenizerTest do
+defmodule Floki.Selector.TokenizerTest do
   use ExUnit.Case, async: true
-  alias Floki.SelectorTokenizer
+  alias Floki.Selector.Tokenizer
 
   test "empty selector" do
-    assert SelectorTokenizer.tokenize("") == []
+    assert Tokenizer.tokenize("") == []
   end
 
   test "complex selector" do
@@ -14,7 +14,7 @@ defmodule Floki.SelectorTokenizerTest do
     a > b
     """
 
-    assert SelectorTokenizer.tokenize(complex) == [
+    assert Tokenizer.tokenize(complex) == [
       {:identifier, 1, 'ns'},
       {:namespace_pipe, 1},
       {:identifier, 1, 'a'},
@@ -42,7 +42,7 @@ defmodule Floki.SelectorTokenizerTest do
   end
 
   test "prefix match with quoted val" do
-    assert SelectorTokenizer.tokenize("#about-us[href^='contact']") == [
+    assert Tokenizer.tokenize("#about-us[href^='contact']") == [
       {:hash, 1, 'about-us'},
       {'[', 1},
         {:identifier, 1, 'href'},
@@ -53,48 +53,48 @@ defmodule Floki.SelectorTokenizerTest do
   end
 
   test "an unknown token" do
-    assert SelectorTokenizer.tokenize("&") == [
+    assert Tokenizer.tokenize("&") == [
       {:unknown, 1, '&'}
     ]
   end
 
   test "pseudo classes" do
-    assert SelectorTokenizer.tokenize(":nth-child(3)") == [
+    assert Tokenizer.tokenize(":nth-child(3)") == [
       {:pseudo, 1, 'nth-child'},
       {:pseudo_class_int, 1, 3}
     ]
 
-    assert SelectorTokenizer.tokenize(":nth-child(odd)") == [
+    assert Tokenizer.tokenize(":nth-child(odd)") == [
       {:pseudo, 1, 'nth-child'},
       {:pseudo_class_odd, 1}
     ]
 
-    assert SelectorTokenizer.tokenize(":nth-child(even)") == [
+    assert Tokenizer.tokenize(":nth-child(even)") == [
       {:pseudo, 1, 'nth-child'},
       {:pseudo_class_even, 1}
     ]
 
-    assert SelectorTokenizer.tokenize(":nth-child(2n+1)") == [
+    assert Tokenizer.tokenize(":nth-child(2n+1)") == [
       {:pseudo, 1, 'nth-child'},
       {:pseudo_class_pattern, 1, '2n+1'}
     ]
 
-    assert SelectorTokenizer.tokenize(":nth-child(2n-1)") == [
+    assert Tokenizer.tokenize(":nth-child(2n-1)") == [
       {:pseudo, 1, 'nth-child'},
       {:pseudo_class_pattern, 1, '2n-1'}
     ]
 
-    assert SelectorTokenizer.tokenize(":nth-child(n+0)") == [
+    assert Tokenizer.tokenize(":nth-child(n+0)") == [
       {:pseudo, 1, 'nth-child'},
       {:pseudo_class_pattern, 1, 'n+0'}
     ]
 
-    assert SelectorTokenizer.tokenize(":nth-child(-n+6)") == [
+    assert Tokenizer.tokenize(":nth-child(-n+6)") == [
       {:pseudo, 1, 'nth-child'},
       {:pseudo_class_pattern, 1, '-n+6'}
     ]
 
-    assert SelectorTokenizer.tokenize(":fl-contains('foo')") == [
+    assert Tokenizer.tokenize(":fl-contains('foo')") == [
       {:pseudo, 1, 'fl-contains'},
       {:pseudo_class_quoted, 1, 'foo'}
     ]

--- a/test/floki/selector_test.exs
+++ b/test/floki/selector_test.exs
@@ -1,8 +1,8 @@
 defmodule Floki.SelectorTest do
   use ExUnit.Case, async: true
 
-  alias Floki.{AttributeSelector, Selector, Combinator}
-  alias Selector.PseudoClass
+  alias Floki.Selector
+  alias Selector.{AttributeSelector, PseudoClass, Combinator}
 
   test "to_string/1 (String.Chars protocol)" do
     attribute1 = %AttributeSelector{match_type: :equal, attribute: "href", value: "#home"}


### PR DESCRIPTION
Moves some modules to the `lib/floki/selector` path in order to better
organize the code.