### PR TITLE
Renames Floki.transform/2 and Floki.Finder#apply_transformation/2

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -218,14 +218,24 @@ defmodule Floki do
     |> Enum.map(fn(html_node) -> HTMLTree.to_tuple(tree, html_node) end)
   end
 
-  def transform(html_tree_list, transformation) when is_list(html_tree_list) do
-    Enum.map(html_tree_list, fn(html_tree) ->
-      Finder.apply_transformation(html_tree, transformation)
-    end)
+  @doc """
+  It receives a HTML tree structure as tuple and maps
+  through all nodes with a given function that receives
+  a tuple with {name, attributes}.
+
+  It returns that structure transformed by the function.
+
+  ## Examples
+
+      iex> html = {"div", [{"class", "foo"}], ["text"]}
+      iex> Floki.map(html, fn({name, attrs}) -> {name, [{"data-name", "bar"} | attrs]} end)
+      {"div", [{"data-name", "bar"}, {"class", "foo"}], ["text"]}
+
+  """
+  def map(html_tree_list, fun) when is_list(html_tree_list) do
+    Enum.map(html_tree_list, &(Finder.map(&1, fun)))
   end
-  def transform(html_tree, transformation) do
-    Finder.apply_transformation(html_tree, transformation)
-  end
+  def map(html_tree, fun), do: Finder.map(html_tree, fun)
 
   @doc """
   Returns the text nodes from a HTML tree.

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -30,17 +30,14 @@ defmodule Floki.Finder do
     find_selectors(html_tree, [selector])
   end
 
-  # Not documented yet because it's an experimental API
-  def apply_transformation({name, attrs, rest}, transformation) do
-    {new_name, new_attrs} = transformation.({name, attrs})
+  @spec map(html_tree, function) :: html_tree
 
-    new_rest = Enum.map(rest, fn(html_tree) ->
-      apply_transformation(html_tree, transformation)
-    end)
+  def map({name, attrs, rest}, fun) do
+    {new_name, new_attrs} = fun.({name, attrs})
 
-    {new_name, new_attrs, new_rest}
+    {new_name, new_attrs, Enum.map(rest, &(map(&1, fun)))}
   end
-  def apply_transformation(other, _transformation), do: other
+  def map(other, _fun), do: other
 
   defp find_selectors(html_tuple_or_list, selectors) do
     tree = HTMLTree.build(html_tuple_or_list)

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -702,15 +702,21 @@ defmodule FlokiTest do
     assert Floki.attribute("<a href=#{url}>Google</a>", "href") == [url]
   end
 
-  test "transforms nodes" do
+  test "Floki.map/2 transforms nodes" do
     elements = Floki.find(@html, ".content")
     transformation = fn
       {"a", [{"href", x} | xs]} ->
         {"a", [{"href", String.replace(x, "http://", "https://")} | xs]}
       x -> x
     end
-    transform = Floki.transform(elements, transformation)
-    assert transform |> Floki.find("a") |> Floki.attribute("href") == ["https://google.com", "https://elixir-lang.org", "https://java.com"]
+
+    result = Floki.map(elements, transformation)
+    hrefs_after =
+      result
+      |> Floki.find("a")
+      |> Floki.attribute("href")
+
+    assert hrefs_after == ["https://google.com", "https://elixir-lang.org", "https://java.com"]
   end
 
   test "finding leaf nodes" do


### PR DESCRIPTION
It renames these transformation function to only `map/2` following
@aphillipo's suggestion from https://github.com/philss/floki/issues/118