### PR TITLE
Remove support for Elixir 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: elixir
 elixir:
   - 1.4
   - 1.3
-  - 1.2
 otp_release:
   - 20.0
   - 19.3
@@ -12,8 +11,6 @@ otp_release:
 matrix:
   exclude:
     - elixir: 1.3
-      otp_release: 20.0
-    - elixir: 1.2
       otp_release: 20.0
 
 sudo: false

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Floki.Mixfile do
      name: "Floki",
      version: @version,
      description: @description,
-     elixir: ">= 1.2.0",
+     elixir: ">= 1.3.0",
      package: package(),
      deps: deps(),
      source_url: "https://github.com/philss/floki",


### PR DESCRIPTION
Following the policy of supporting the last three releases, we are
dropping support for Elixir 1.2.

This will enable Floki to use some features that are only available
since version 1.3.