### PR TITLE
Fix `raw_html` for self closing tags with content

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -109,7 +109,7 @@ defmodule Floki do
   defp build_attrs({attr, value}, attrs), do: ~s(#{attrs} #{attr}="#{value}")
   defp build_attrs(attr, attrs), do: "#{attrs} #{attr}"
 
-  defp tag_for(type, attrs, _children) when type in @self_closing_tags do
+  defp tag_for(type, attrs, []) when type in @self_closing_tags do
     case attrs do
       "" -> "<#{type}/>"
       _ -> "<#{type} #{attrs}/>"

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -216,6 +216,18 @@ defmodule FlokiTest do
     assert raw_html == "<div hidden></div>"
   end
 
+  test "raw_html (with self closing tag without content)" do
+    raw_html = Floki.raw_html({"link", [{"href", "www.example.com"}], []})
+
+    assert raw_html == "<link href=\"www.example.com\"/>"
+  end
+
+  test "raw_html (with self closing tag with content)" do
+    raw_html = Floki.raw_html({"link", [], ["www.example.com"]})
+
+    assert raw_html == "<link>www.example.com</link>"
+  end
+
   # Floki.find/2 - Classes
 
   test "find elements with a given class" do


### PR DESCRIPTION
Previously the output of `raw_html` loses any text contained within self
closing tags. For example, parsing and using `raw_html` with the following:

```xml
<item>
  <link>www.example.com</link>
</item>
```

resulted in:

```xml
<item>
  <link/></link>
</item>
```