### PR TITLE
Fix filter out when result is empty

### DIFF
--- a/lib/floki/filter_out.ex
+++ b/lib/floki/filter_out.ex
@@ -30,7 +30,10 @@ defmodule Floki.FilterOut do
 
         case html_tree do
           tree when is_tuple(tree) ->
-            hd(html_as_tuples)
+            case html_as_tuples do
+              [] -> []
+              [head | _] -> head
+            end
           trees when is_list(trees) ->
             html_as_tuples
         end

--- a/test/floki/filter_out_test.exs
+++ b/test/floki/filter_out_test.exs
@@ -12,4 +12,8 @@ defmodule Floki.FilterOutTest do
     assert Floki.FilterOut.filter_out(nodes, "script") == nodes
     assert Floki.FilterOut.filter_out(nodes, :comment) == nodes
   end
+
+  test "filter out filters script when it is the only node" do
+    assert Floki.FilterOut.filter_out({"script", [], ["wat"]}, "script") == []
+  end
 end


### PR DESCRIPTION
It does not break. Returns an empty list instead.
The reason to not return `nil` is to keep the interface only returning
tuples and lists.

It fixes #136 