### PR TITLE
Add :last-child pseudo-class selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Here you find all the [CSS selectors](https://www.w3.org/TR/selectors/#selectors
 | E[foo\|="en"]    | an E element whose "foo" attribute has a hyphen-separated list of values beginning (from the left) with "en" |
 | E:nth-child(n)  | an E element, the n-th child of its parent |
 | E:first-child   | an E element, first child of its parent |
+| E:last-child   | an E element, last child of its parent |
 | E.warning       | an E element whose class is "warning" |
 | E#myid          | an E element with ID equal to "myid" |
 | E:not(s)        | an E element that does not match simple selector s |

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -132,6 +132,8 @@ defmodule Floki.Selector do
         PseudoClass.match_nth_child?(tree, html_node, pseudo_class)
       "first-child" ->
         PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: 1})
+      "last-child" ->
+        PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: -1})
       "not" ->
         Enum.all?(pseudo_class.value, &(!Selector.match?(html_node, &1, tree)))
       "fl-contains" ->

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -52,15 +52,18 @@ defmodule Floki.Selector.PseudoClass do
   end
 
   defp node_position(tree, html_node) do
-    parent_node = Map.get(tree.nodes, html_node.parent_node_id)
-    children_nodes_ids = parent_node.children_nodes_ids
-                         |> Enum.reverse
-                         |> filter_only_html_nodes(tree.nodes)
-                         |> Enum.with_index(1)
-
+    children_nodes_ids = get_children_nodes_ids(tree, html_node.parent_node_id)
     {_node_id, position} = Enum.find(children_nodes_ids, fn({id, _}) -> id == html_node.node_id end)
 
     position
+  end
+
+  defp get_children_nodes_ids(tree, parent_node_id) do
+    parent_node = Map.get(tree.nodes, parent_node_id)
+    parent_node.children_nodes_ids
+    |> Enum.reverse
+    |> filter_only_html_nodes(tree.nodes)
+    |> Enum.with_index(1)
   end
 
   defp filter_only_html_nodes(ids, nodes) do

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -21,6 +21,11 @@ defmodule Floki.Selector.PseudoClass do
   end
 
   def match_nth_child?(_, %HTMLNode{parent_node_id: nil}, _), do: false
+  def match_nth_child?(tree, html_node, %__MODULE__{value: -1}) do
+    children_nodes_ids = get_children_nodes_ids(tree, html_node.parent_node_id)
+    {last_child_id, _} = Enum.max_by(children_nodes_ids, fn({_, pos}) -> pos end)
+    last_child_id == html_node.node_id
+  end
   def match_nth_child?(tree, html_node, %__MODULE__{value: position}) when is_integer(position) do
     node_position(tree, html_node) == position
   end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -587,6 +587,35 @@ defmodule FlokiTest do
     ]
   end
 
+  test "get elements by last-child pseudo-class" do
+    html = """
+    <html>
+    <body>
+      <div>
+        <p>1</p>
+        <p>2</p>
+      </div>
+      ignores this text
+      <!-- also ignores this comment -->
+      <div>
+        <p>3</p>
+        <h2>4</h2>
+      </div>
+      ignores this text
+      <!-- also ignores this comment -->
+    </html>
+    """
+
+    assert Floki.find(html, "p:last-child") == [
+      {"p", [], ["2"]}
+    ]
+
+    assert Floki.find(html, "div :last-child") == [
+      {"p", [], ["2"]},
+      {"h2", [], ["4"]}
+    ]
+  end
+
   test "not pseudo-class" do
     html = """
     <html>


### PR DESCRIPTION
Hello,
This PR closes #143 by adding support for the pseudo-class selector `:last-child`. A matching branch is added to `pseudo_class_match?/3` in `Floki.Selector`. Also, the `node_position/2` in `Floki.Selector.PseudoClass` is now split to `node_position/2` and `get_children_nodes_ids/2`.