### PR TITLE
Add :nth-of-type(n), :first-of-type, and :last-of-type pseudo-class selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ Here you find all the [CSS selectors](https://www.w3.org/TR/selectors/#selectors
 | E:nth-child(n)  | an E element, the n-th child of its parent |
 | E:first-child   | an E element, first child of its parent |
 | E:last-child   | an E element, last child of its parent |
+| E:nth-of-type(n)  | an E element, the n-th child of its type among its siblings |
+| E:first-of-type   | an E element, first child of its type among its siblings |
+| E:last-of-type   | an E element, last child of its type among its siblings |
 | E.warning       | an E element whose class is "warning" |
 | E#myid          | an E element with ID equal to "myid" |
 | E:not(s)        | an E element that does not match simple selector s |

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -134,6 +134,12 @@ defmodule Floki.Selector do
         PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: 1})
       "last-child" ->
         PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: -1})
+      "nth-of-type" ->
+        PseudoClass.match_nth_of_type?(tree, html_node, pseudo_class)
+      "first-of-type" ->
+        PseudoClass.match_nth_of_type?(tree, html_node, %PseudoClass{name: "nth-of-type", value: 1})
+      "last-of-type" ->
+        PseudoClass.match_nth_of_type?(tree, html_node, %PseudoClass{name: "nth-of-type", value: -1})
       "not" ->
         Enum.all?(pseudo_class.value, &(!Selector.match?(html_node, &1, tree)))
       "fl-contains" ->

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -47,7 +47,7 @@ defmodule Floki.Selector.PseudoClass do
 
   def match_nth_of_type?(_, %HTMLNode{parent_node_id: nil}, _), do: false
   def match_nth_of_type?(tree, html_node, %__MODULE__{value: -1}) do
-    children_nodes_ids = get_children_nodes_indexed_by_type(tree, html_node.parent_node_id, html_node.type)
+    children_nodes_ids = get_children_nodes_indexed_by_type(tree, html_node)
     {last_child_id, _} = Enum.max_by(children_nodes_ids, fn({_, pos}) -> pos end)
     last_child_id == html_node.node_id
   end
@@ -87,7 +87,7 @@ defmodule Floki.Selector.PseudoClass do
   end
 
   defp node_type_position(tree, html_node) do
-    children_nodes_ids = get_children_nodes_indexed_by_type(tree, html_node.parent_node_id, html_node.type)
+    children_nodes_ids = get_children_nodes_indexed_by_type(tree, html_node)
     find_node_position(children_nodes_ids, html_node.node_id)
   end
 
@@ -102,9 +102,9 @@ defmodule Floki.Selector.PseudoClass do
     Enum.with_index(nodes, 1)
   end
 
-  defp get_children_nodes_indexed_by_type(tree, parent_node_id, type) do
-    get_children_nodes(tree, parent_node_id)
-    |> filter_nodes_by_type(tree.nodes, type)
+  defp get_children_nodes_indexed_by_type(tree, html_node) do
+    get_children_nodes(tree, html_node.parent_node_id)
+    |> filter_nodes_by_type(tree.nodes, html_node.type)
     |> Enum.with_index(1)
   end
 

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -616,6 +616,58 @@ defmodule FlokiTest do
     ]
   end
 
+  test "get elements by nth-of-type, first-of-type, and last-of-type pseudo-classes" do
+    html = """
+    <html>
+    <body>
+      ignores this text
+      <h1>Child 1</h1>
+      <!-- also ignores this comment -->
+      <div>Child 2</div>
+      <div>Child 3</div>
+      <div>Child 4</div>
+      <a href="/a">1</a>
+      ignores this text
+      <a href="/b">2</a>
+      <a href="/c">3</a>
+      <!-- also ignores this comment -->
+      <a href="/d">4</a>
+      <a href="/e">5</a>
+    </html>
+    """
+
+    assert Floki.find(html, "a:nth-of-type(2)") == [
+      {"a", [{"href", "/b"}], ["2"]}
+    ]
+
+    assert Floki.find(html, "a:nth-of-type(even)") == [
+      {"a", [{"href", "/b"}], ["2"]},
+      {"a", [{"href", "/d"}], ["4"]}
+    ]
+
+    assert Floki.find(html, "a:nth-of-type(odd)") == [
+      {"a", [{"href", "/a"}], ["1"]},
+      {"a", [{"href", "/c"}], ["3"]},
+      {"a", [{"href", "/e"}], ["5"]}
+    ]
+
+    assert Floki.find(html, "a:first-of-type") == [
+      {"a", [{"href", "/a"}], ["1"]}
+    ]
+
+    assert Floki.find(html, "body :first-of-type") == [
+      {"h1", [], ["Child 1"]},
+      {"div", [], ["Child 2"]},
+      {"a", [{"href", "/a"}], ["1"]}
+    ]
+
+    assert Floki.find(html, "body :last-of-type") == [
+      {"h1", [], ["Child 1"]},
+      {"div", [], ["Child 4"]},
+      {"a", [{"href", "/e"}], ["5"]}
+    ]
+  end
+
   test "not pseudo-class" do
     html = """
     <html>


### PR DESCRIPTION
Hello,
This PR closes #144 by adding support for the pseudo-class selectors: `:nth-of-child(n)`, `:first-of-type` and `:last-of-type`.