### PR TITLE
FIX Functional notation whitespace and negative b

### DIFF
--- a/lib/floki/selector/functional.ex
+++ b/lib/floki/selector/functional.ex
@@ -4,7 +4,7 @@ defmodule Floki.Selector.Functional do
 
   defstruct [:stream, :a, :b]
 
-  @regex ~r/^(?<a>[-+]?[0-9]*[n])\+?(?<b>[0-9]*)$/
+  @regex ~r/^\s*(?<a>[-+]?[0-9]*[n])\s*(?<b>[+-]\s*[0-9]+)?\s*$/
 
   def parse(expr) when is_list(expr) do
     parse(to_string(expr))
@@ -19,8 +19,8 @@ defmodule Floki.Selector.Functional do
 
   defp build(a, ""), do: build(a, "0")
   defp build(a, b) do
-    a = parse_a(a)
-    b = String.to_integer(b)
+    a = parse_num(a)
+    b = parse_num(b)
     stream = Stream.map(0..100_000, fn x ->
       a * x + b
     end)
@@ -28,12 +28,15 @@ defmodule Floki.Selector.Functional do
     %__MODULE__{stream: stream, a: a, b: b}
   end
 
-  defp parse_a(a) do
-    case String.trim(a, "n") do
-      "-" -> -1
-      "" -> 1
-      n -> String.to_integer(n)
-    end
+  defp parse_num(n_str) do
+      n_str
+      |> String.replace(" ", "")
+      |> String.trim("n")
+      |> case do
+           "-" -> -1
+           "" -> 1
+           n -> String.to_integer(n)
+         end
   end
 
   defimpl String.Chars do

--- a/test/floki/selector/functional_test.exs
+++ b/test/floki/selector/functional_test.exs
@@ -6,11 +6,13 @@ defmodule Floki.Selector.FunctionalTest do
     assert :invalid == Functional.parse("")
     assert :invalid == Functional.parse("not a fn")
     assert :invalid == Functional.parse("odden")
-    assert :invalid == Functional.parse("2n-3")
+    assert :invalid == Functional.parse("2n-")
+    assert :invalid == Functional.parse("10n+-1")
+    assert :invalid == Functional.parse("10n-+1")
+    assert :invalid == Functional.parse("3 n")
+    assert :invalid == Functional.parse("+ 2n")
+    assert :invalid == Functional.parse("+ 2")
   end
-
-  # :nth-child(5n)
-  # Represents elements 5, 10, 15, etc.
 
   test "An" do
     assert {:ok, f} = Functional.parse("5n")
@@ -39,6 +41,15 @@ defmodule Floki.Selector.FunctionalTest do
     end
   end
 
+  test "negative complement" do
+    assert {:ok, f} = Functional.parse("4n-1")
+    assert %Functional{a: 4, b: -1} = f
+
+    for n <- [3, 7, 11, 15] do
+      assert n in f.stream
+    end
+  end
+
   test "complete function" do
     assert {:ok, f} = Functional.parse("3n+4")
     assert %Functional{a: 3, b: 4} = f
@@ -46,5 +57,19 @@ defmodule Floki.Selector.FunctionalTest do
     for n <- [4, 7, 10, 13] do
       assert n in f.stream
     end
+  end
+
+  test "whitespace" do
+    assert {:ok, f} = Functional.parse("  3n + 4  ")
+    assert %Functional{a: 3, b: 4} = f
+
+    assert {:ok, f} = Functional.parse(" 3n + 1 ")
+    assert %Functional{a: 3, b: 1} = f
+
+    assert {:ok, f} = Functional.parse(" +3n - 2 ")
+    assert %Functional{a: 3, b: -2} = f
+
+    assert {:ok, f} = Functional.parse(" -n+ 6")
+    assert %Functional{a: -1, b: 6} = f
   end
 end


### PR DESCRIPTION
Now it should be according to spec: https://drafts.csswg.org/selectors-3/#nth-child-pseudo
Thanks, @mischov!