### PR TITLE
Add functional notation to nth-of-type pseudo-class selector

### DIFF
--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -80,6 +80,11 @@ defmodule Floki.Selector.PseudoClass do
     rem(position, 2) == 1
   end
 
+  def match_nth_of_type?(tree, html_node, %__MODULE__{value: %Functional{stream: s}}) do
+    position = node_type_position(tree, html_node)
+    position in s
+  end
+
   def match_nth_of_type?(_, _, %__MODULE__{value: expression}) do
     Logger.warn(fn ->
       "Pseudo-class nth-of-type with expressions like #{inspect(expression)} are not supported yet. Ignoring."

--- a/test/floki/selector/functional_test.exs
+++ b/test/floki/selector/functional_test.exs
@@ -36,7 +36,7 @@ defmodule Floki.Selector.FunctionalTest do
     assert {:ok, f} = Functional.parse("n")
     assert %Functional{a: 1, b: 0} = f
 
-    for n <- 0..1_000 do
+    for n <- 0..1000 do
       assert n in f.stream
     end
   end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -690,6 +690,18 @@ defmodule FlokiTest do
              {"a", [{"href", "/e"}], ["5"]}
            ]
 
+    # same as nth-of-type(odd)
+    assert Floki.find(html, "a:nth-of-type(2n+1)") == [
+             {"a", [{"href", "/a"}], ["1"]},
+             {"a", [{"href", "/c"}], ["3"]},
+             {"a", [{"href", "/e"}], ["5"]}
+           ]
+
+    # same as first-of-type
+    assert Floki.find(html, "a:nth-of-type(0n+1)") == [
+             {"a", [{"href", "/a"}], ["1"]}
+           ]
+
     assert Floki.find(html, "a:first-of-type") == [
              {"a", [{"href", "/a"}], ["1"]}
            ]


### PR DESCRIPTION
Following the implementation from https://github.com/philss/floki/pull/150