### PR TITLE
support raw text into `Floki.raw_html`

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -86,10 +86,11 @@ defmodule Floki do
 
   """
 
-  @spec raw_html(html_tree) :: binary
+  @spec raw_html(html_tree | binary) :: binary
 
   def raw_html(html_tree), do: raw_html(html_tree, "")
   defp raw_html([], html), do: html
+  defp raw_html(string, _html) when is_binary(string), do: string
   defp raw_html(tuple, html) when is_tuple(tuple), do: raw_html([tuple], html)
   defp raw_html([string|tail], html) when is_binary(string), do: raw_html(tail, html <> string)
   defp raw_html([{:comment, comment}|tail], html), do: raw_html(tail, html <> "<!--#{comment}-->")

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -170,6 +170,21 @@ defmodule FlokiTest do
     assert raw_html == original_without_spaces
   end
 
+  test "raw_html (with plain text)" do
+    raw_html =
+      "plain text node"
+      |> Floki.parse
+      |> Floki.raw_html
+
+    raw_without_spaces =
+      raw_html
+      |> String.split("\n")
+      |> Enum.map(&(String.trim(&1)))
+      |> Enum.join("")
+
+    assert raw_html == raw_without_spaces
+  end
+
   test "raw_html (html with data attributes)" do
     raw_html =
       @html_with_data_attributes


### PR DESCRIPTION
Given the fact that `Floki.parse` might return plain text, it makes sense
that `Floki.raw_html` would handle that situation. Currently, plain text
will not match and function signatures for `raw_html` causing an error like
this:

```
"some text"
|> Floki.parse
|> Floki.raw_html

** (FunctionClauseError) no function clause matching in Floki.raw_html/2

The following arguments were given to Floki.raw_html/2:

    # 1
    "some text"

    # 2
    ""

Attempted function clauses (showing 6 out of 6):

    defp raw_html([], html)
    defp raw_html(tuple, html) when is_tuple(tuple)
    defp raw_html([string | tail], html) when is_binary(string)
    defp raw_html([{:comment, comment} | tail], html)
    defp raw_html([{:pi, "xml", attrs} | tail], html)
    defp raw_html([{type, attrs, children} | tail], html)
```

This add a simple signature to just return the plain text if it is given.

/cc @philss 