### PR TITLE
Handle doctype in raw_html, fixes #155

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -118,6 +118,16 @@ defmodule Floki do
     raw_html(tail, html <> "<?xml " <> tag_attrs(attrs) <> "?>")
   end
 
+  defp raw_html([{:doctype, type, public, system} | tail], html) do
+    attr =
+      case {public, system} do
+        {"", ""} -> ""
+        {"", system} -> " SYSTEM \"#{system}\""
+        {public, system} -> " PUBLIC \"#{public}\" \"#{system}\""
+      end
+    raw_html(tail, html <> "<!DOCTYPE #{type}#{attr}>")
+  end
+
   defp raw_html([{type, attrs, children} | tail], html) do
     raw_html(tail, html <> tag_for(type, tag_attrs(attrs), children))
   end


### PR DESCRIPTION
Not sure how to add tests but the cases I tried were

`<!DOCTYPE html>`
`<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">`
`<!DOCTYPE note SYSTEM "Note.dtd">`

using `Floki.parse()` and `Floki.raw_html()`