### PR TITLE
Re-encode HTML entities on Floki.raw_html/1

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -107,9 +107,12 @@ defmodule Floki do
 
   def raw_html(html_tree), do: raw_html(html_tree, "")
   defp raw_html([], html), do: html
-  defp raw_html(string, _html) when is_binary(string), do: string
+  defp raw_html(string, _html) when is_binary(string), do: HtmlEntities.encode(string)
   defp raw_html(tuple, html) when is_tuple(tuple), do: raw_html([tuple], html)
-  defp raw_html([string | tail], html) when is_binary(string), do: raw_html(tail, html <> string)
+
+  defp raw_html([string | tail], html) when is_binary(string) do
+    raw_html(tail, html <> HtmlEntities.encode(string))
+  end
 
   defp raw_html([{:comment, comment} | tail], html),
     do: raw_html(tail, html <> "<!--#{comment}-->")

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule Floki.Mixfile do
   defp deps do
     [
       {:mochiweb, "~> 2.15"},
+      {:html_entities, "~> 0.4.0"},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.14", only: :dev},
       {:credo, ">= 0.0.0", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "credo": {:hex, :credo, "0.8.8", "990e7844a8d06ebacd88744a55853a83b74270b8a8461c55a4d0334b8e1736c9", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [], [], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -193,6 +193,9 @@ defmodule FlokiTest do
 
     assert Floki.raw_html(html_with_doctype) ==
              "<!DOCTYPE html><html><head><title>hello</title></head><body><h1>world</h1></body></html>"
+
+    span_with_entities = "<span>&lt;video&gt; São Paulo</span>"
+    assert Floki.parse(span_with_entities) |> Floki.raw_html() == span_with_entities
   end
 
   test "raw_html (with plain text)" do


### PR DESCRIPTION
We need to represent the HTML entities as they originally are,
since the reparsing of the output should generate the same document.

It fixes https://github.com/philss/floki/issues/158