### PR TITLE
Updated specs for Floki.parse/1

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -66,7 +66,7 @@ defmodule Floki do
 
   """
 
-  @spec parse(binary) :: html_tree | binary
+  @spec parse(binary) :: html_tree | String.t()
 
   def parse(html) do
     HTMLParser.parse(html)

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -66,7 +66,7 @@ defmodule Floki do
 
   """
 
-  @spec parse(binary) :: html_tree
+  @spec parse(binary) :: html_tree | binary
 
   def parse(html) do
     HTMLParser.parse(html)


### PR DESCRIPTION
`Floki.parse/1` returns binary when the string is not html, so the specs should cover it. Alternatively, you could change the `html_tree` type.