### PR TITLE
Remove Enumerable.slice compile warning

### DIFF
--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -214,6 +214,10 @@ defmodule Floki.HTMLTree do
       {:ok, false}
     end
 
+    def slice(_) do
+      {:error, __MODULE__}
+    end
+
     def reduce(html_tree, state, fun) do
       do_reduce(%{html_tree | node_ids: Enum.reverse(html_tree.node_ids)}, state, fun)
     end


### PR DESCRIPTION
When compiling floki, there is a compile warning that gets spit out:
```
==> floki
Compiling 1 file (.xrl)
Compiling 1 file (.erl)
Compiling 21 files (.ex)
warning: function slice/1 required by protocol Enumerable is not implemented (in module Enumerable.Floki.HTMLTree)
  lib/floki/html_tree.ex:202

Generated floki app
```
The docs for `Enumerable` specify that `{:error, __MODULE__}` causes a default algorithm built on top of reduce/3 that runs in linear time will be used.