### PR TITLE
Fix style and script tags with comments

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -93,8 +93,9 @@ defmodule Floki.RawHTML do
 
   defp build_attrs(attr, attrs), do: "#{attrs} #{attr}"
 
-  defp tag_for(type, attrs, content, _encoder) when type in ["script", "style"] do
-    tag_with_attrs(type, attrs, []) <> Enum.join(content) <> "</#{type}>"
+  defp tag_for(type, attrs, children, _encoder) when type in ["script", "style"] do
+    tag_with_attrs(type, attrs, children) <>
+      build_raw_html(children, "", & &1) <> close_end_tag(type, children)
   end
 
   defp tag_for(type, attrs, children, encoder) do

--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -93,12 +93,12 @@ defmodule Floki.RawHTML do
 
   defp build_attrs(attr, attrs), do: "#{attrs} #{attr}"
 
-  defp tag_for(type, attrs, children, _encoder) when type in ["script", "style"] do
-    tag_with_attrs(type, attrs, children) <>
-      build_raw_html(children, "", & &1) <> close_end_tag(type, children)
-  end
-
   defp tag_for(type, attrs, children, encoder) do
+    encoder = case type do
+                "script" -> & &1
+                "style"  -> & &1
+                _        -> encoder
+              end
     tag_with_attrs(type, attrs, children) <>
       build_raw_html(children, "", encoder) <> close_end_tag(type, children)
   end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -313,6 +313,12 @@ defmodule FlokiTest do
     assert rerendered_tree == tree
   end
 
+  test "raw_html (with style tag with comments" do
+    html = "<style><!-- test --></style>"
+
+    assert Floki.parse(html) |> Floki.raw_html() == html
+  end
+
   test "raw_html can configure encoding" do
     input = "<body>< \"test\" ></body>"
     encoded_output = "<body>&lt; &quot;test&quot; &gt;</body>"


### PR DESCRIPTION
In case of an html comment inside `style` or `script` tags, `Floki.raw_html` raise an error `(Protocol.UndefinedError) protocol String.Chars not implemented for {:comment, "...."}`.

So instead of reimplementing the serialization, I removed the default encoder to not encode html entities.