### PR TITLE
Check type of attribute values

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -83,7 +83,11 @@ defmodule Floki.RawHTML do
   defp close_end_tag(type, []) when type in @self_closing_tags, do: ""
   defp close_end_tag(type, _), do: "</#{type}>"
 
-  defp build_attrs({attr, value}, attrs) do
+  defp build_attrs({attr, iodata}, attrs) when is_list(iodata) do
+    build_attrs({attr, IO.iodata_to_binary(iodata)}, attrs)
+  end
+
+  defp build_attrs({attr, <<value::binary>>}, attrs) do
     if String.contains?(value, "\"") do
       ~s(#{attrs} #{attr}='#{value}')
     else
@@ -91,7 +95,7 @@ defmodule Floki.RawHTML do
     end
   end
 
-  defp build_attrs(attr, attrs), do: "#{attrs} #{attr}"
+  defp build_attrs(<<attr::binary>>, attrs), do: "#{attrs} #{attr}"
 
   defp tag_for(type, attrs, children, encoder) do
     encoder =

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -273,6 +273,11 @@ defmodule FlokiTest do
     assert raw_html == "<div hidden></div>"
   end
 
+  test "raw_html with attribute as iodata" do
+    raw_html = Floki.raw_html({"div", [{"class", ["class1", " ", ["class", "2"]]}], []})
+    assert raw_html == ~s(<div class="class1 class2"></div>)
+  end
+
   test "raw_html (with self closing tag without content)" do
     raw_html = Floki.raw_html({"link", [{"href", "www.example.com"}], []})
 


### PR DESCRIPTION
fixes https://github.com/philss/floki/issues/188

Adds a type check to `Floki.RawHTML.build_attrs/2`, to ensure that the attributes are a string before checking for double quotes inside of attributes.