### PR TITLE
Change the level of logging from warn to info

### DIFF
--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -181,7 +181,7 @@ defmodule Floki.Selector do
   end
 
   defp pseudo_class_match?(_html_node, %{name: unknown_pseudo_class}, _tree) do
-    Logger.warn(fn ->
+    Logger.info(fn ->
       "Pseudo-class #{inspect(unknown_pseudo_class)} is not implemented. Ignoring."
     end)
 

--- a/lib/floki/selector/parser.ex
+++ b/lib/floki/selector/parser.ex
@@ -142,7 +142,7 @@ defmodule Floki.Selector.Parser do
   end
 
   defp do_parse([{:unknown, _, unknown} | t], selector) do
-    Logger.warn(fn -> "Unknown token #{inspect(unknown)}. Ignoring." end)
+    Logger.info(fn -> "Unknown token #{inspect(unknown)}. Ignoring." end)
 
     do_parse(t, selector)
   end
@@ -172,7 +172,7 @@ defmodule Floki.Selector.Parser do
   end
 
   defp consume_attribute(:consuming, [unknown | t], attr_selector) do
-    Logger.warn(fn -> "Unknown token #{inspect(unknown)}. Ignoring." end)
+    Logger.info(fn -> "Unknown token #{inspect(unknown)}. Ignoring." end)
     consume_attribute(:consuming, t, attr_selector)
   end
 
@@ -249,7 +249,7 @@ defmodule Floki.Selector.Parser do
   end
 
   defp update_pseudo_not_value(_pseudo_class, _pseudo_not_selector) do
-    Logger.warn("Only simple selectors are allowed in :not() pseudo-class. Ignoring.")
+    Logger.info("Only simple selectors are allowed in :not() pseudo-class. Ignoring.")
     nil
   end
 end

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -51,7 +51,7 @@ defmodule Floki.Selector.PseudoClass do
   end
 
   def match_nth_child?(_tree, _html_node, %__MODULE__{value: expression}) do
-    Logger.warn(fn ->
+    Logger.info(fn ->
       "Pseudo-class nth-child with expressions like #{inspect(expression)} are not supported yet. Ignoring."
     end)
 
@@ -87,7 +87,7 @@ defmodule Floki.Selector.PseudoClass do
   end
 
   def match_nth_of_type?(_, _, %__MODULE__{value: expression}) do
-    Logger.warn(fn ->
+    Logger.info(fn ->
       "Pseudo-class nth-of-type with expressions like #{inspect(expression)} are not supported yet. Ignoring."
     end)
 


### PR DESCRIPTION
Fix for Issue #192 

Sets the level of logging to info in case tokens get ignored