### PR TITLE
make code more compliant to  advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This is recommended if you need [better performance](https://gist.github.com/phi
 and a more accurate parser. However `html5ever` is being under active development and **may be unstable**.
 
 Since it's written in Rust, we need to install Rust and compile the project.
-Luckily we have have the [html5ever Elixir NIF](https://github.com/hansihe/html5ever_elixir) that makes the integration very easy.
+Luckily we have the [html5ever Elixir NIF](https://github.com/hansihe/html5ever_elixir) that makes the integration very easy.
 
 You still need to install Rust in your system. To do that, please
 [follow the instruction](https://www.rust-lang.org/en-US/install.html) presented in the official page.

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -321,7 +321,7 @@ defmodule FlokiTest do
   test "raw_html (with style tag with comments" do
     html = "<style><!-- test --></style>"
 
-    assert Floki.parse(html) |> Floki.raw_html() == html
+    assert html |> Floki.parse() |> Floki.raw_html() == html
   end
 
   test "raw_html can configure encoding" do


### PR DESCRIPTION
Now this is the output of `mix credo`:

```shell
> mix credo --strict
Ignoring an undefined check: Credo.Check.Readability.NoParenthesesWhenZeroArity
Ignoring an undefined check: Credo.Check.Warning.NameRedeclarationByAssignment
Ignoring an undefined check: Credo.Check.Warning.NameRedeclarationByCase
Ignoring an undefined check: Credo.Check.Warning.NameRedeclarationByDef
Ignoring an undefined check: Credo.Check.Warning.NameRedeclarationByFn
Checking 31 source files ...

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.9 seconds (0.02s to load, 0.9s running checks)
306 mods/funs, found no issues.
```