### PR TITLE
Update html5ever version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ After setup Rust, you need to add `html5ever` NIF to your dependency list:
 defp deps do
   [
     {:floki, "~> 0.20.0"},
-    {:html5ever, "~> 0.6.1"}
+    {:html5ever, "~> 0.7.0"}
   ]
 end
 ```


### PR DESCRIPTION
Update html5ever version in the readme to the newest one. It is compatible with Erlang/OTP 21 unlike the previous version.