### PR TITLE
Fix typespec for filter_out

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -388,7 +388,7 @@ defmodule Floki do
 
   """
 
-  @spec filter_out(binary | html_tree, binary) :: list
+  @spec filter_out(binary | html_tree, FilterOut.selector()) :: list
 
   def filter_out(html_tree, selector) when is_binary(html_tree) do
     html_tree

--- a/lib/floki/filter_out.ex
+++ b/lib/floki/filter_out.ex
@@ -6,7 +6,7 @@ defmodule Floki.FilterOut do
   # Helper functions for filtering out a specific element from the tree.
 
   @type html_tree :: tuple | list
-  @type selector :: binary
+  @type selector :: :comment | Finder.selector()
 
   @spec filter_out(html_tree, selector) :: tuple | list
 


### PR DESCRIPTION
ElixirLS was complaining about `Floki.filter_out(_, :comment)`