### PR TITLE
Introduces Floki.children/2 function

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -303,6 +303,37 @@ defmodule Floki do
   end
 
   @doc """
+  Returns the direct child nodes of a HTML tree.
+
+  By default, it will also include all texts. You can disable this behaviour
+  by using the option `include_text` to `false`
+
+  ## Examples
+
+      iex> Floki.children({"div", [], ["text", {"span", [], []}]})
+      ["text", {"span", [], []}]
+
+      iex> Floki.children({"div", [], ["text", {"span", [], []}]}, include_text: false)
+      [{"span", [], []}]
+
+  """
+
+  @spec children(html_tree, Keyword.t()) :: html_tree
+
+  def children(html, opts \\ [include_text: true]) do
+    case html do
+      {_, _, subtree} ->
+        filter_children(subtree, opts[:include_text])
+
+      _ ->
+        nil
+    end
+  end
+
+  defp filter_children(children, false), do: Enum.filter(children, &is_tuple(&1))
+  defp filter_children(children, _), do: children
+
+  @doc """
   Returns a list with attribute values for a given selector.
 
   ## Examples

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -941,6 +941,32 @@ defmodule FlokiTest do
     assert Floki.find(@html, "a,div") == Floki.find(@html, [selector_struct_1, selector_struct_2])
   end
 
+  # Floki.children/2
+
+  test "returns the children elements of an element including the text" do
+    html = "<div>a parent<span>a child</span></div>"
+    elements = Floki.parse(html)
+    expected = ["a parent", {"span", [], ["a child"]}]
+
+    result = Floki.children(elements)
+
+    assert result == expected
+  end
+
+  test "returns the children elements of an element without the text" do
+    html = "<div>a parent<span>child 1</span>some text<span>child 2</span></div>"
+    elements = Floki.parse(html)
+    expected = [{"span", [], ["child 1"]}, {"span", [], ["child 2"]}]
+
+    result = Floki.children(elements, include_text: false)
+
+    assert result == expected
+  end
+
+  test "returns nil if the given html is not a valid tuple" do
+    assert Floki.children("<div>not<span>valid</span></div>") == nil
+  end
+
   # Floki.attribute/3
 
   test "get attribute values from elements with a given class" do


### PR DESCRIPTION
This new function returns the direct child nodes of a HTML tree, optionally
excluding text nodes, specially useful for pipes:

```elixir
my_html
|> Floki.find(".my-selector")
|> Floki.children(include_text: false)
|> Enum.map(&my_transform_func/1)
```

Inspired by #215