### PR TITLE
Change Ebert README badge name to SourceLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Floki version](https://img.shields.io/hexpm/v/floki.svg)](https://hex.pm/packages/floki)
 [![Hex.pm](https://img.shields.io/hexpm/dt/floki.svg)](https://hex.pm/packages/floki)
 [![Inline docs](https://inch-ci.org/github/philss/floki.svg?branch=master)](https://inch-ci.org/github/philss/floki)
-[![Ebert](https://ebertapp.io/github/philss/floki.svg)](https://ebertapp.io/github/philss/floki)
+[![SourceLevel](https://app.sourcelevel.io/github/philss/floki.svg)](https://app.sourcelevel.io/github/philss/floki)
 
 <img src="assets/images/floki-logo-with-type.svg" width="500" alt="Floki logo">
 


### PR DESCRIPTION
There was a change in the name of the service

https://sourcelevel.io/ebert-is-now-sourcelevel