### PR TITLE
Add issue templates to make easier to open issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve the project.
+title: ''
+labels: Bug
+assignees: ''
+
+---
+
+## Description
+
+A clear and concise description of what the bug is, including the code used
+and the exception stacktrace, if any.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+- Using Floki v0.x.x
+- Using Elixir v1.x.x
+- Using Erlang OTP v20.x.x
+- With this code:
+  ```elixir
+  # An example to reproduce the problem
+  ```
+
+## Expected behavior
+
+A description of what is the expected behavior using the code.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,22 @@
+---
+name: Feature
+about: Create a good feature description to improve the project.
+title: ''
+labels: Feature
+assignees: ''
+
+---
+
+## Feature goal
+
+A clear and concise description of what this feature is intent to solve, including examples if
+possible.
+
+```elixir
+# Here you can add some examples for the new API
+```
+
+## Dependencies
+
+A list of dependencies to implement this feature. A dependency can be a software dependency,
+a bug fix, documentation or some decision that is pending from another issue.


### PR DESCRIPTION
The objective is to improve the flow for people opening new issues.

It was based on AppSignal's Elixir package:
https://github.com/appsignal/appsignal-elixir