### PR TITLE
Fix parsing when cannot decode a charref correctly

### DIFF
--- a/src/floki_mochi_html.erl
+++ b/src/floki_mochi_html.erl
@@ -702,8 +702,13 @@ tokenize_charref_raw(Bin, S=#decoder{offset=O}, Start) ->
             %% CHANGED: Previously this was mochiweb_charref:charref/1
             %% but the functionality below is equivalent;
             <<_:Start/binary, Raw:Len/binary, _/binary>> = Bin,
-            <<CP/utf8>> = 'Elixir.HtmlEntities':decode(<<$&, Raw/binary, $;>>),
-            {CP, ?INC_COL(S)};
+
+            case 'Elixir.HtmlEntities':decode(<<$&, Raw/binary, $;>>) of
+              <<CP/utf8>> ->
+                {CP, ?INC_COL(S)};
+              _ ->
+                throw(invalid_charref)
+            end;
         _ ->
             tokenize_charref_raw(Bin, ?INC_COL(S), Start)
     end.

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -9,6 +9,7 @@ defmodule FlokiTest do
   <title>Test</title>
   </head>
   <body>
+    <a href="http://foo.com/blah?hi=blah&foo=&#43;Park" class="foo">test</a>
     <div class="content">
       <a href="http://google.com" class="js-google js-cool">Google</a>
       <a href="http://elixir-lang.org" class="js-elixir js-cool">Elixir lang</a>
@@ -115,6 +116,11 @@ defmodule FlokiTest do
                  "body",
                  [],
                  [
+                   {
+                     "a",
+                     [{"href", "http://foo.com/blah?hi=blah&foo=+Park"}, {"class", "foo"}],
+                     ["test"]
+                   },
                    {
                      "div",
                      [{"class", "content"}],


### PR DESCRIPTION
It throws an error to the parser so it can ignore the decode of charref
when it can't get back a valid UTF8 codepoint.

This fixes #233, #235 and #237.