### PR TITLE
Add fast_html parser and test all parsers on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,32 +5,39 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PARSER: ${{ matrix.parser }}
 
     container:
       image: elixir:${{ matrix.elixir }}-slim
 
-    name: Elixir ${{ matrix.elixir }}
+    name: Elixir ${{ matrix.elixir }} with ${{ matrix.parser }}
 
     strategy:
+      fail-fast: false
       matrix:
         elixir: [1.9, 1.8, 1.7, 1.6, 1.5]
+        parser: [fast_html, html5ever, mochiweb]
 
     steps:
       - uses: actions/checkout@v1.0.0
 
       - name: Install dependencies
         run: |-
+          apt-get update
+          if [ "$PARSER" = "fast_html" ]; then apt-get -y install build-essential; fi
+          if [ "$PARSER" = "html5ever" ]; then apt-get -y install cargo; fi
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
 
       - name: Check format
-        if: matrix.elixir >= 1.6
+        if: matrix.elixir >= 1.8
         run: mix format --check-formatted
 
       - name: Run tests
         run: |-
-          mix test
+          mix test.$PARSER
 
       - name: Run inch.report
         if: matrix.elixir >= 1.7

--- a/lib/floki/html_parser/fast_html.ex
+++ b/lib/floki/html_parser/fast_html.ex
@@ -1,0 +1,16 @@
+defmodule Floki.HTMLParser.FastHtml do
+  @moduledoc false
+
+  def parse(html) do
+    case Code.ensure_loaded(:fast_html) do
+      {:module, module} ->
+        case module.decode(html) do
+          {:ok, result} -> result
+          {:error, _message} = error -> error
+        end
+
+      {:error, _reason} ->
+        raise "Expected module :fast_html to be available."
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule Floki.Mixfile do
       elixir: "~> 1.5",
       package: package(),
       deps: deps(),
+      aliases: aliases(),
       source_url: "https://github.com/philss/floki",
       docs: [extras: ["README.md"], main: "Floki", assets: "assets"]
     ]
@@ -28,8 +29,50 @@ defmodule Floki.Mixfile do
       {:earmark, "~> 1.2", only: :dev},
       {:ex_doc, "~> 0.18", only: :dev},
       {:credo, ">= 0.0.0", only: [:dev, :test]},
-      {:inch_ex, ">= 0.0.0", only: :docs}
+      {:inch_ex, ">= 0.0.0", only: :docs},
+      {:html5ever, ">= 0.0.0", optional: true, only: [:dev, :test]},
+      {:fast_html, ">= 0.0.0", optional: true, only: [:dev, :test]},
+      {:mochiweb, ">= 0.0.0", optional: true, only: [:dev, :test]}
     ]
+  end
+
+  defp aliases do
+    parsers = get_parsers()
+
+    {aliases, cli_names} =
+      Enum.map_reduce(parsers, [], fn parser, acc ->
+        cli_name =
+          parser
+          |> Module.split()
+          |> List.last()
+          |> Macro.underscore()
+
+        {{:"test.#{cli_name}", &test_with_parser(parser, &1)}, [cli_name | acc]}
+      end)
+
+    aliases
+    |> Keyword.put(:test, &test_with_parser(cli_names, &1))
+  end
+
+  # Hardcoded because we can't load the floki application and get the module list at this point.
+  defp get_parsers() do
+    [Floki.HTMLParser.Mochiweb, Floki.HTMLParser.FastHtml, Floki.HTMLParser.Html5ever]
+  end
+
+  # Hack: If Mix.Task.Test.run is called the second time, it won't run any tests
+  defp test_with_parser(parser_cli_names, args) when is_list(parser_cli_names) do
+    Enum.each(parser_cli_names, fn cli_name ->
+      Mix.shell().cmd("mix test.#{cli_name} --color #{Enum.join(args, " ")}",
+        env: [{"MIX_ENV", "test"}]
+      )
+    end)
+  end
+
+  defp test_with_parser(parser, args) do
+    Mix.shell().info("Running tests with #{parser}")
+    Application.put_env(:floki, :html_parser, parser, persistent: true)
+    Mix.env(:test)
+    Mix.Tasks.Test.run(args)
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,8 @@
   "credo": {:hex, :credo, "1.1.5", "caec7a3cadd2e58609d7ee25b3931b129e739e070539ad1a0cd7efeeb47014f4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "fast_html": {:hex, :fast_html, "1.0.0", "eb73ab6dc4d1498b3760489629487fc6b82e0df71c316171a425a71deff2fdcf", [:make, :mix], [], "hexpm"},
+  "html5ever": {:hex, :html5ever, "0.7.0", "9f63ec1c783b2dc9f326840fcc993c01e926dbdef4e51ba1bbe5355993c258b4", [:mix], [{:rustler, "~> 0.18.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
   "html_entities": {:hex, :html_entities, "0.5.0", "40f5c5b9cbe23073b48a4e69c67b6c11974f623a76165e2b92d098c0e88ccb1d", [:mix], [], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "2.0.0", "24268a9284a1751f2ceda569cd978e1fa394c977c45c331bb52a405de544f4de", [:mix], [{:bunt, "~> 0.2", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
@@ -11,4 +13,5 @@
   "mochiweb": {:hex, :mochiweb, "2.18.0", "eb55f1db3e6e960fac4e6db4e2db9ec3602cc9f30b86cd1481d56545c3145d2e", [:rebar3], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "rustler": {:hex, :rustler, "0.18.0", "db4bd0c613d83a1badc31be90ddada6f9821de29e4afd15c53a5da61882e4f2d", [:mix], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "credo": {:hex, :credo, "1.1.5", "caec7a3cadd2e58609d7ee25b3931b129e739e070539ad1a0cd7efeeb47014f4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "fast_html": {:hex, :fast_html, "1.0.0", "eb73ab6dc4d1498b3760489629487fc6b82e0df71c316171a425a71deff2fdcf", [:make, :mix], [], "hexpm"},
+  "fast_html": {:hex, :fast_html, "1.0.1", "5bc7df4dc4607ec2c314c16414e4111d79a209956c4f5df96602d194c61197f9", [:make, :mix], [], "hexpm"},
   "html5ever": {:hex, :html5ever, "0.7.0", "9f63ec1c783b2dc9f326840fcc993c01e926dbdef4e51ba1bbe5355993c258b4", [:mix], [{:rustler, "~> 0.18.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
   "html_entities": {:hex, :html_entities, "0.5.0", "40f5c5b9cbe23073b48a4e69c67b6c11974f623a76165e2b92d098c0e88ccb1d", [:mix], [], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "2.0.0", "24268a9284a1751f2ceda569cd978e1fa394c977c45c331bb52a405de544f4de", [:mix], [{:bunt, "~> 0.2", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,7 @@
+# fast_html uses a C-Node worker for parsing, so starting the application
+# is necessary for it to work
+if Application.get_env(:floki, :html_parser) == Floki.HTMLParser.FastHtml do
+  Application.ensure_all_started(:fast_html)
+end
+
 ExUnit.start()


### PR DESCRIPTION
Closes #234, closes #156 

Note that:
1. Currently html5ever and fast_html are failing exactly the same tests, I am guessing that's because of #236 and I think this should be solved in a separate PR.
2. The test code is pretty hacky, would be nice if `System.cmd` could be avoided, but I can't figure out why is `ExUnit` not running the tests without it.