### PR TITLE
Floki.traverse_and_update with an accumulator

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -339,6 +339,40 @@ defmodule Floki do
   defdelegate traverse_and_update(html_tree, fun), to: Floki.Traversal
 
   @doc """
+  Traverses and updates a HTML tree structure with an accumulator.
+
+  This function returns a new tree structure and the final value of accumulator
+  which are the result of applying the given `fun` on all nodes.
+
+  The function `fun` receives a tuple with `{name, attributes, children}` and
+  an accumulator, and should return a 2-tuple like `{new_node, new_acc}`, where
+  `new_node` is either a similar tuple or `nil` to delete the current node, and
+  `new_acc` is an updated value for the accumulator.
+
+  ## Examples
+
+      iex> html = [{"div", [], ["hello"]}, {"div", [], ["world"]}]
+      iex> Floki.traverse_and_update(html, 0, fn {"div", attrs, children}, acc ->
+      ...>   {{"p", [{"data-count", to_string(acc)} | attrs], children}, acc + 1}
+      ...> end)
+      {[
+         {"p", [{"data-count", "0"}], ["hello"]},
+         {"p", [{"data-count", "1"}], ["world"]}
+       ], 2}
+
+      iex> html = {"div", [], [{"span", [], ["hello"]}]}
+      iex> Floki.traverse_and_update(html, [deleted: 0], fn
+      ...>   {"span", _attrs, _children}, acc ->
+      ...>     {nil, Keyword.put(acc, :deleted, acc[:deleted] + 1)}
+      ...>   tag, acc ->
+      ...>     {tag, acc}
+      ...> end)
+      {{"div", [], []}, [deleted: 1]}
+  """
+
+  defdelegate traverse_and_update(html_tree, acc, fun), to: Floki.Traversal
+
+  @doc """
   Returns the text nodes from a HTML tree.
   By default, it will perform a deep search through the HTML tree.
   You can disable deep search with the option `deep` assigned to false.

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -323,16 +323,27 @@ defmodule Floki do
   def map(html_tree, fun), do: Finder.map(html_tree, fun)
 
   @doc """
-  Traverses a HTML tree structure and returns a new tree structure that is the result of executing a function on all nodes. The function receives a tuple with {name, attributes, children}, and should either return a similar tuple or `nil` to delete the current node.
+  Traverses and updates a HTML tree structure.
+
+  This function returns a new tree structure that is the result of applying the
+  given `fun` on all nodes.
+
+  The function `fun` receives a tuple with `{name, attributes, children}`, and
+  should either return a similar tuple or `nil` to delete the current node.
 
   ## Examples
 
       iex> html = {"div", [], ["hello"]}
-      iex> Floki.traverse_and_update(html, fn {"div", attrs, children} -> {"p", attrs, children} end)
+      iex> Floki.traverse_and_update(html, fn {"div", attrs, children} ->
+      ...>   {"p", attrs, children}
+      ...> end)
       {"p", [], ["hello"]}
 
       iex> html = {"div", [], [{"span", [], ["hello"]}]}
-      iex> Floki.traverse_and_update(html, fn {"span", _attrs, _children} -> nil; tag -> tag end)
+      iex> Floki.traverse_and_update(html, fn
+      ...>   {"span", _attrs, _children} -> nil
+      ...>   tag -> tag
+      ...> end)
       {"div", [], []}
   """
 

--- a/lib/floki/traversal.ex
+++ b/lib/floki/traversal.ex
@@ -22,4 +22,30 @@ defmodule Floki.Traversal do
   def traverse_and_update({:comment, children}, fun), do: fun.({:comment, children})
 
   def traverse_and_update(doctype = {:doctype, _, _, _}, fun), do: fun.(doctype)
+
+  def traverse_and_update(text, acc, _fun) when is_binary(text), do: {text, acc}
+
+  def traverse_and_update([head | tail], acc, fun) do
+    case traverse_and_update(head, acc, fun) do
+      {nil, new_acc} ->
+        traverse_and_update(tail, new_acc, fun)
+
+      {mapped_head, new_acc} ->
+        {mapped_tail, new_acc2} = traverse_and_update(tail, new_acc, fun)
+        {[mapped_head | mapped_tail], new_acc2}
+    end
+  end
+
+  def traverse_and_update([], acc, _fun), do: {[], acc}
+
+  def traverse_and_update(xml_tag = {:pi, _, _}, acc, fun), do: fun.(xml_tag, acc)
+
+  def traverse_and_update({elem, attrs, children}, acc, fun) do
+    {mapped_children, new_acc} = traverse_and_update(children, acc, fun)
+    fun.({elem, attrs, mapped_children}, new_acc)
+  end
+
+  def traverse_and_update({:comment, children}, acc, fun), do: fun.({:comment, children}, acc)
+
+  def traverse_and_update(doctype = {:doctype, _, _, _}, acc, fun), do: fun.(doctype, acc)
 end

--- a/lib/floki/traversal.ex
+++ b/lib/floki/traversal.ex
@@ -1,7 +1,12 @@
 defmodule Floki.Traversal do
   @moduledoc false
 
+  def traverse_and_update(html_node, fun)
+  def traverse_and_update([], _fun), do: []
   def traverse_and_update(text, _fun) when is_binary(text), do: text
+  def traverse_and_update(xml_tag = {:pi, _, _}, fun), do: fun.(xml_tag)
+  def traverse_and_update({:comment, children}, fun), do: fun.({:comment, children})
+  def traverse_and_update(doctype = {:doctype, _, _, _}, fun), do: fun.(doctype)
 
   def traverse_and_update([head | tail], fun) do
     case traverse_and_update(head, fun) do
@@ -10,20 +15,17 @@ defmodule Floki.Traversal do
     end
   end
 
-  def traverse_and_update([], _fun), do: []
-
-  def traverse_and_update(xml_tag = {:pi, _, _}, fun), do: fun.(xml_tag)
-
   def traverse_and_update({elem, attrs, children}, fun) do
     mapped_children = traverse_and_update(children, fun)
     fun.({elem, attrs, mapped_children})
   end
 
-  def traverse_and_update({:comment, children}, fun), do: fun.({:comment, children})
-
-  def traverse_and_update(doctype = {:doctype, _, _, _}, fun), do: fun.(doctype)
-
+  def traverse_and_update(html_node, acc, fun)
+  def traverse_and_update([], acc, _fun), do: {[], acc}
   def traverse_and_update(text, acc, _fun) when is_binary(text), do: {text, acc}
+  def traverse_and_update(xml_tag = {:pi, _, _}, acc, fun), do: fun.(xml_tag, acc)
+  def traverse_and_update({:comment, children}, acc, fun), do: fun.({:comment, children}, acc)
+  def traverse_and_update(doctype = {:doctype, _, _, _}, acc, fun), do: fun.(doctype, acc)
 
   def traverse_and_update([head | tail], acc, fun) do
     case traverse_and_update(head, acc, fun) do
@@ -36,16 +38,8 @@ defmodule Floki.Traversal do
     end
   end
 
-  def traverse_and_update([], acc, _fun), do: {[], acc}
-
-  def traverse_and_update(xml_tag = {:pi, _, _}, acc, fun), do: fun.(xml_tag, acc)
-
   def traverse_and_update({elem, attrs, children}, acc, fun) do
     {mapped_children, new_acc} = traverse_and_update(children, acc, fun)
     fun.({elem, attrs, mapped_children}, new_acc)
   end
-
-  def traverse_and_update({:comment, children}, acc, fun), do: fun.({:comment, children}, acc)
-
-  def traverse_and_update(doctype = {:doctype, _, _, _}, acc, fun), do: fun.(doctype, acc)
 end

--- a/test/floki/traversal_test.exs
+++ b/test/floki/traversal_test.exs
@@ -76,4 +76,87 @@ defmodule Floki.TraversalTest do
              ]
     end
   end
+
+  describe "traverse_and_update/3" do
+    test "with string returns string and the original accumulator value" do
+      assert Floki.traverse_and_update("hello", 0, fn tag, acc ->
+               {tag, acc + 1}
+             end) == {"hello", 0}
+    end
+
+    test "with div and identity function returns div" do
+      html = {"div", [], ["hello"]}
+
+      assert Floki.traverse_and_update(html, 0, fn tag, acc ->
+               {tag, acc + 1}
+             end) == {html, 1}
+    end
+
+    test "with div and div->p function returns p" do
+      html = {"div", [], ["hello"]}
+
+      assert Floki.traverse_and_update(html, 0, fn {"div", attrs, children}, acc ->
+               {{"p", attrs, children}, acc + 1}
+             end) == {{"p", [], ["hello"]}, 1}
+    end
+
+    test "with style attribute and style->src function returns src attribute" do
+      html = {"div", [{"style", "display: flex"}], ["hello"]}
+
+      assert Floki.traverse_and_update(html, 0, fn {elem, _attrs, children}, acc ->
+               {{elem, [{"src", "http://example.test"}], children}, acc + 1}
+             end) == {{"div", [{"src", "http://example.test"}], ["hello"]}, 1}
+    end
+
+    test "with text child and child replacer function returns tag with new child" do
+      html = {"div", [], ["hello"]}
+
+      assert Floki.traverse_and_update(html, 0, fn {elem, attrs, _children}, acc ->
+               {{elem, attrs, ["world"]}, acc + 1}
+             end) == {{"div", [], ["world"]}, 1}
+    end
+
+    test "with div->span and span deleter function returns div without span" do
+      html = {"div", [], [{"span", [], ["hello"]}]}
+
+      assert Floki.traverse_and_update(html, 0, fn
+               {"span", _attrs, _children}, acc -> {nil, acc + 1}
+               tag, acc -> {tag, acc + 1}
+             end) == {{"div", [], []}, 2}
+    end
+
+    test "with div,p and identity function returns div,p" do
+      html = [{"div", [], ["hello"]}, {"p", [], ["world"]}]
+
+      assert Floki.traverse_and_update(html, 0, fn tag, acc ->
+               {tag, acc + 1}
+             end) == {html, 2}
+    end
+
+    test "with comment, pi and doctype elements" do
+      html = [
+        {:doctype, "html", nil, nil},
+        {"body", [],
+         [
+           {"div", [], ["hello"]},
+           {:comment, "a comment"},
+           {:pi, "xml", []}
+         ]}
+      ]
+
+      assert Floki.traverse_and_update(html, 0, fn
+               {:comment, text}, acc -> {{"span", [], [text]}, acc + 1}
+               {:pi, "xml", _children}, acc -> {nil, acc + 1}
+               {:doctype, "html", nil, nil}, acc -> {nil, acc + 1}
+               tag, acc -> {tag, acc + 1}
+             end) ==
+               {[
+                  {"body", [],
+                   [
+                     {"div", [], ["hello"]},
+                     {"span", [], ["a comment"]}
+                   ]}
+                ], 5}
+    end
+  end
 end


### PR DESCRIPTION
Closes #246.

This pull request will add the `Floki.traverse_and_update/3` function, which is described in the above issue.

Aside from that:

- In 48799f9b2851a0fc91a6bc5172a1343a806d341a, I tried to reorganize existing function clauses in `Floki.Traversal` to make the code look more concise.
- And in 1ef0529f94adda7218fbe425d769c185f8c6a650, I tried modifying the existing function documentation of `Floki.traverse_and_update/2` to make it look nicer in ExDoc documentation.

Please let me know if there is anything I have missed. :smile: 