### PR TITLE
Add E:nth-last-child(n) and E:nth-last-of-type(n) pseudo-class selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,11 @@ Here you find all the [CSS selectors](https://www.w3.org/TR/selectors/#selectors
 | E[foo*="bar"]   | an E element whose "foo" attribute value contains the substring "bar" |
 | E[foo\|="en"]    | an E element whose "foo" attribute has a hyphen-separated list of values beginning (from the left) with "en" |
 | E:nth-child(n)  | an E element, the n-th child of its parent |
+| E:nth-last-child(n)  | an E element, the n-th child of its parent, counting from bottom to up |
 | E:first-child   | an E element, first child of its parent |
 | E:last-child   | an E element, last child of its parent |
 | E:nth-of-type(n)  | an E element, the n-th child of its type among its siblings |
+| E:nth-last-of-type(n)  | an E element, the n-th child of its type among its siblings, counting from bottom to up |
 | E:first-of-type   | an E element, first child of its type among its siblings |
 | E:last-of-type   | an E element, last child of its type among its siblings |
 | E.warning       | an E element whose class is "warning" |

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -151,7 +151,14 @@ defmodule Floki.Selector do
   end
 
   defp pseudo_class_match?(html_node, %{name: "last-child"}, tree) do
-    PseudoClass.match_nth_child?(tree, html_node, %PseudoClass{name: "nth-child", value: -1})
+    PseudoClass.match_nth_last_child?(tree, html_node, %PseudoClass{
+      name: "nth-last-child",
+      value: 1
+    })
+  end
+
+  defp pseudo_class_match?(html_node, pseudo_class = %{name: "nth-last-child"}, tree) do
+    PseudoClass.match_nth_last_child?(tree, html_node, pseudo_class)
   end
 
   defp pseudo_class_match?(html_node, pseudo_class = %{name: "nth-of-type"}, tree) do

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -173,10 +173,14 @@ defmodule Floki.Selector do
   end
 
   defp pseudo_class_match?(html_node, %{name: "last-of-type"}, tree) do
-    PseudoClass.match_nth_of_type?(tree, html_node, %PseudoClass{
-      name: "nth-of-type",
-      value: -1
+    PseudoClass.match_nth_last_of_type?(tree, html_node, %PseudoClass{
+      name: "nth-last-of-type",
+      value: 1
     })
+  end
+
+  defp pseudo_class_match?(html_node, pseudo_class = %{name: "nth-last-of-type"}, tree) do
+    PseudoClass.match_nth_last_of_type?(tree, html_node, pseudo_class)
   end
 
   defp pseudo_class_match?(html_node, pseudo_class = %{name: "not"}, tree) do

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -25,15 +25,6 @@ defmodule Floki.Selector.PseudoClass do
 
   def match_nth_child?(_tree, %HTMLNode{parent_node_id: nil}, _pseudo_class), do: false
 
-  def match_nth_child?(tree, html_node, %__MODULE__{value: -1}) do
-    {last_child_id, _} =
-      tree
-      |> indexed_children_nodes(html_node)
-      |> Enum.max_by(fn {_, pos} -> pos end)
-
-    last_child_id == html_node.node_id
-  end
-
   def match_nth_child?(tree, html_node, %__MODULE__{value: value}) do
     relative_position =
       tree
@@ -61,6 +52,17 @@ defmodule Floki.Selector.PseudoClass do
       |> node_position(html_node)
 
     match_position?(value, relative_position, "nth-of-type")
+  end
+
+  def match_nth_last_child?(_, %HTMLNode{parent_node_id: nil}, _), do: false
+
+  def match_nth_last_child?(tree, html_node, %__MODULE__{value: value}) do
+    relative_position =
+      tree
+      |> reverse_indexed_children_nodes(html_node)
+      |> node_position(html_node)
+
+    match_position?(value, relative_position, "nth-last-child")
   end
 
   def match_contains?(tree, html_node, %__MODULE__{value: value}) do
@@ -123,6 +125,19 @@ defmodule Floki.Selector.PseudoClass do
     parent_node.children_nodes_ids
     |> Enum.reverse()
     |> filter_only_html_nodes(tree.nodes)
+  end
+
+  defp reverse_children_nodes(tree, parent_node_id) do
+    parent_node = Map.get(tree.nodes, parent_node_id)
+
+    parent_node.children_nodes_ids
+    |> filter_only_html_nodes(tree.nodes)
+  end
+
+  defp reverse_indexed_children_nodes(tree, html_node) do
+    tree
+    |> reverse_children_nodes(html_node.parent_node_id)
+    |> Enum.with_index(1)
   end
 
   defp filter_only_html_nodes(ids, nodes) do

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,6 @@
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
-  "rustler": {:hex, :rustler, "0.21.0", "68cc4fc015d0b9541865ea78e78e9ef2dd91ee4be80bf543fd15791102a45aca", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm"},
-  "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm"},
+  "rustler": {:hex, :rustler, "0.21.0", "68cc4fc015d0b9541865ea78e78e9ef2dd91ee4be80bf543fd15791102a45aca", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "e5429378c397f37f1091a35593b153aee1925e197c6842d04648d802edb52f80"},
+  "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm", "f1e3dabef71fb510d015fad18c0e05e7c57281001141504c6b69d94e99750a07"},
 }

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -609,6 +609,49 @@ defmodule FlokiTest do
            ]
   end
 
+  test "get elements by nth-last-child pseudo-class" do
+    html = """
+    <html>
+    <body>
+      <a href="/a">1</a>
+      ignores this text
+      <a href="/b">2</a>
+      <a href="/c">3</a>
+      <!-- also ignores this comment -->
+      <a href="/d">4</a>
+      <a href="/e">5</a>
+      <a href="/f">6</a>
+      <a href="/g">7</a>
+    </html>
+    """
+
+    assert Floki.find(document!(html), "a:nth-last-child(2)") == [
+             {"a", [{"href", "/f"}], ["6"]}
+           ]
+
+    assert Floki.find(document!(html), "a:nth-last-child(even)") == [
+             {"a", [{"href", "/b"}], ["2"]},
+             {"a", [{"href", "/d"}], ["4"]},
+             {"a", [{"href", "/f"}], ["6"]}
+           ]
+
+    assert Floki.find(document!(html), "a:nth-last-child(odd)") == [
+             {"a", [{"href", "/a"}], ["1"]},
+             {"a", [{"href", "/c"}], ["3"]},
+             {"a", [{"href", "/e"}], ["5"]},
+             {"a", [{"href", "/g"}], ["7"]}
+           ]
+
+    assert Floki.find(document!(html), "a:nth-last-child(0n+1)") == [
+             {"a", [{"href", "/g"}], ["7"]}
+           ]
+
+    assert Floki.find(document!(html), "a:nth-last-child(3n+4)") == [
+             {"a", [{"href", "/a"}], ["1"]},
+             {"a", [{"href", "/d"}], ["4"]}
+           ]
+  end
+
   test "get elements by last-child pseudo-class" do
     html = """
     <html>

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -699,6 +699,7 @@ defmodule FlokiTest do
         <!-- also ignores this comment -->
         <a href="/d">4</a>
         <a href="/e">5</a>
+      </body>
       </html>
       """)
 
@@ -742,6 +743,52 @@ defmodule FlokiTest do
     assert Floki.find(html, "body :last-of-type") == [
              {"h1", [], ["Child 1"]},
              {"div", [], ["Child 4"]},
+             {"a", [{"href", "/e"}], ["5"]}
+           ]
+  end
+
+  test "get elements by nth-last-of-type pseudo-classes" do
+    html =
+      document!("""
+      <html>
+      <body>
+        ignores this text
+        <h1>Child 1</h1>
+        <!-- also ignores this comment -->
+        <a href="/a">1</a>
+        <div>Child 2</div>
+        <div>Child 3</div>
+        <div>Child 4</div>
+        ignores this text
+        <a href="/b">2</a>
+        <a href="/c">3</a>
+        <!-- also ignores this comment -->
+        <a href="/d">4</a>
+        <a href="/e">5</a>
+      </html>
+      """)
+
+    assert Floki.find(html, "a:nth-last-of-type(2)") == [
+             {"a", [{"href", "/d"}], ["4"]}
+           ]
+
+    assert Floki.find(html, "div:nth-last-of-type(even)") == [
+             {"div", [], ["Child 3"]}
+           ]
+
+    assert Floki.find(html, "a:nth-last-of-type(odd)") == [
+             {"a", [{"href", "/a"}], ["1"]},
+             {"a", [{"href", "/c"}], ["3"]},
+             {"a", [{"href", "/e"}], ["5"]}
+           ]
+
+    assert Floki.find(html, "a:nth-last-of-type(2n+1)") == [
+             {"a", [{"href", "/a"}], ["1"]},
+             {"a", [{"href", "/c"}], ["3"]},
+             {"a", [{"href", "/e"}], ["5"]}
+           ]
+
+    assert Floki.find(html, "a:nth-last-of-type(0n+1)") == [
              {"a", [{"href", "/e"}], ["5"]}
            ]
   end


### PR DESCRIPTION
It adds these two selectors following the examples from [MDN Web docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference).

Closes #257 