### PR TITLE
Use hexpm Docker images for our CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,16 @@ jobs:
       PARSER: ${{ matrix.parser }}
 
     container:
-      image: elixir:${{ matrix.elixir }}-slim
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.erlang }}-ubuntu-${{ matrix.ubuntu }}
 
-    name: Elixir ${{ matrix.elixir }} with ${{ matrix.parser }}
+    name: Elixir ${{ matrix.elixir }} / Erlang ${{ matrix.erlang }} with ${{ matrix.parser }} and Ubuntu ${{matrix.ubuntu}}
 
     strategy:
       fail-fast: false
       matrix:
-        elixir: [1.9, 1.8, 1.7, 1.6]
+        elixir: ["1.9.4", "1.8.2", "1.7.4", "1.6.6"]
+        erlang: ["21.3.8"]
+        ubuntu: ["bionic-20200219"]
         parser: [fast_html, html5ever, mochiweb]
 
     steps:


### PR DESCRIPTION
It replaces the "official" imagens with images provided by the Hex team,
which are updated automatically for each branch and tag created on the
Elixir project. They are probably more stable and are released faster
than the official channel.

For more details see https://elixirforum.com/t/yet-another-elixir-and-erlang-docker-image/28740
And also check https://github.com/hexpm/bob