### PR TITLE
Support Encoding More Entities in Floki.raw_html

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -117,7 +117,7 @@ defmodule Floki.RawHTML do
   # html_escape
 
   def html_escape_attribute_value(attribute_value) do
-    html_escape_chars(attribute_value, ~r/&|"/)
+    html_escape_chars(attribute_value, ~r/&|"|<|>|'/)
   end
 
   defp html_escape_chars(subject, escaped_chars_regex) do

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -191,7 +191,9 @@ defmodule FlokiTest do
   end
 
   test "raw_html (with both quote and double quote inside the attribute)" do
-    expected_html = "<html><head></head><body><span data-stuff=\"&quot;'\"></span></body></html>"
+    expected_html =
+      "<html><head></head><body><span data-stuff=\"&quot;&#39;\"></span></body></html>"
+
     tree = document!(html_body("<span data-stuff=\"&quot;&#39;\"></span>"))
     assert Floki.raw_html(tree) == expected_html
 
@@ -199,6 +201,20 @@ defmodule FlokiTest do
     assert Floki.raw_html(tree) == expected_html
 
     tree = document!(html_body("<span data-stuff=\"&quot;'\"></span>"))
+    assert Floki.raw_html(tree) == expected_html
+  end
+
+  test "raw_html (with >)" do
+    expected_html = "<html><head></head><body><span data-stuff=\"&gt;\"></span></body></html>"
+
+    tree = document!(html_body("<span data-stuff=\">\"></span>"))
+    assert Floki.raw_html(tree) == expected_html
+  end
+
+  test "raw_html (with <)" do
+    expected_html = "<html><head></head><body><span data-stuff=\"&lt;\"></span></body></html>"
+
+    tree = document!(html_body("<span data-stuff=\"<\"></span>"))
     assert Floki.raw_html(tree) == expected_html
   end
 


### PR DESCRIPTION
`Floki.raw_html` appears to encode HTML entities on attributes using
`html_escape_attribute_value/1`, but the regular expression left out
`<`, `>`, and `'` despite having clauses that match those characters in
`html_escape_char/1`. This adds those three characters to the regular
expression match, and adds unit tests to that effect.

It's also possible this was intentional and I'm missing something, so if
so I'm happy to hear why and I can close this PR.