### PR TITLE
It uses the correct signature for filter_out/2

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -599,7 +599,7 @@ defmodule Floki do
       iex> Floki.filter_out({"div", [], [{"script", [], ["hello"]}, " world"]}, "script")
       {"div", [], [" world"]}
 
-      iex> Floki.filter_out([{"body", [], [{"script", [], []},{"div", [], []}]}], "script")
+      iex> Floki.filter_out([{"body", [], [{"script", [], []}, {"div", [], []}]}], "script")
       [{"body", [], [{"div", [], []}]}]
 
       iex> Floki.filter_out({"div", [], [{:comment, "comment"}, " text"]}, :comment)
@@ -610,7 +610,8 @@ defmodule Floki do
 
   """
 
-  @spec filter_out(binary | html_tree, FilterOut.selector()) :: list
+  @spec filter_out(binary() | html_tree() | html_tag(), FilterOut.selector()) ::
+          html_tree() | html_tag()
 
   def filter_out(html, selector) when is_binary(html) do
     IO.warn(

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -10,7 +10,7 @@ defmodule Floki.Finder do
   alias HTMLTree.HTMLNode
 
   @type html_tree :: tuple | list
-  @type selector :: binary | %Selector{} | [%Selector{}]
+  @type selector :: binary() | %Selector{} | [%Selector{}]
 
   # Find elements inside a HTML tree.
   # Second argument can be either a selector string, a selector struct or a list of selector structs.


### PR DESCRIPTION
Fix the spec to indicate that the function accepts `Floki.html_tag()` too.

fixes #269 