### PR TITLE
Drop support for Elixir 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ["1.9.4", "1.8.2", "1.7.4", "1.6.6"]
-        erlang: ["21.3.8"]
+        elixir: ["1.10.4", "1.9.4", "1.8.2", "1.7.4"]
+        erlang: ["21.3", "22.3", "23.0"]
         ubuntu: ["bionic-20200219"]
         parser: [fast_html, html5ever, mochiweb]
-        # nimble_pool, which fast_html depends on,
-        # does not work on Elixir 1.6.6
         exclude:
-          - elixir: "1.6.6"
-            parser: fast_html
+          - elixir: "1.9.4"
+            erlang: "23.0"
+          - elixir: "1.8.2"
+            erlang: "23.0"
+          - elixir: "1.7.4"
+            erlang: "23.0"
 
     steps:
       - uses: actions/checkout@v1.0.0

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ concerns:
 - Performance - It can be [up to 20 times slower than the alternatives](https://hexdocs.pm/fast_html/readme.html#benchmarks) on big HTML
   documents.
 - Correctness - in some cases `mochiweb_html` will produce different results
-  from what is specified in [HTML5 specification](https://html.spec.whatwg.org/)](https://html.spec.whatwg.org/).
+  from what is specified in [HTML5 specification](https://html.spec.whatwg.org/).
   For example, a correct parser would parse `<title> <b> bold </b> text </title>`
   as `{"title", [], [" <b> bold </b> text "]}` since content inside `<title>` is
   to be [treated as plaintext](https://html.spec.whatwg.org/#the-title-element).

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Floki.Mixfile do
       name: "Floki",
       version: @version,
       description: @description,
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       package: package(),
       deps: deps(),
       aliases: aliases(),


### PR DESCRIPTION
We should only support the 3 latest versions. Since we are too many versions behind, I choose to keep the 4 latest versions and we drop 1.7 soon.