### PR TITLE
Fix Mochiweb parse error when there is a XML inside HTML

### DIFF
--- a/src/floki_mochi_html.erl
+++ b/src/floki_mochi_html.erl
@@ -624,9 +624,8 @@ find_qgt(Bin, S=#decoder{offset=O}) ->
                         ?ADV_COL(S, 1);
         <<_:O/binary, "/>", _/binary>> ->
                         ?ADV_COL(S, 2);
-        %% tokenize_attributes takes care of this state:
-        %% <<_:O/binary, C, _/binary>> ->
-        %%     find_qgt(Bin, ?INC_CHAR(S, C));
+        <<_:O/binary, C, _/binary>> ->
+          find_qgt(Bin, ?INC_CHAR(S, C));
         <<_:O/binary>> ->
             S
     end.


### PR DESCRIPTION
The fix was commented in the code. This also adds a test case with the
difference result expected by each parser.

If closes #305 