### PR TITLE
Deprecate Floki.map/2 and introduce Floki.find_and_update/3

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -333,7 +333,7 @@ defmodule Floki do
       iex>   other ->
       iex>     other
       iex> end)
-      iex> # => [{"a", [{"href", "https://elixir-lang.com"}], ["Elixir"]}]
+      [{"a", [{"href", "https://elixir-lang.com"}], ["Elixir"]}]
   """
 
   @spec find_and_update(

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -323,7 +323,7 @@ defmodule Floki do
   This function works in a way similar to `traverse_and_update`, but instead of updating
   the children nodes, it will only updates the `tag` and `attributes` of the matching nodes.
 
-  If `fun` returns `nil`, the HTML node will be removed from the tree.
+  If `fun` returns `:delete`, the HTML node will be removed from the tree.
 
   ## Examples
 
@@ -339,7 +339,7 @@ defmodule Floki do
   @spec find_and_update(
           html_tree(),
           Finder.selector(),
-          ({String.t(), [html_attribute()]} -> {String.t(), [html_attribute()]} | nil)
+          ({String.t(), [html_attribute()]} -> {String.t(), [html_attribute()]} | :delete)
         ) :: html_tree()
   def find_and_update(html_tree, selector, fun) do
     {tree, results} = Finder.find(html_tree, selector)
@@ -351,11 +351,8 @@ defmodule Floki do
             {updated_tag, updated_attrs} ->
               {:update, %{html_node | type: updated_tag, attributes: updated_attrs}}
 
-            nil ->
+            :delete ->
               {:delete, html_node}
-
-            _ ->
-              {:no_op, html_node}
           end
 
         other ->

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -334,7 +334,6 @@ defmodule Floki do
       iex>     other
       iex> end)
       iex> # => [{"a", [{"href", "https://elixir-lang.com"}], ["Elixir"]}]
-
   """
 
   @spec find_and_update(

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -69,6 +69,8 @@ defmodule Floki do
   @type html_node :: html_comment() | html_doctype() | html_tag() | html_declaration()
   @type html_tree :: [html_node()]
 
+  @type css_selector :: String.t() | Floki.Selector.t() | [Floki.Selector.t()]
+
   @doc """
   Parses a HTML Document from a String.
 
@@ -204,7 +206,7 @@ defmodule Floki do
 
   """
 
-  @spec find(binary | html_tree, binary) :: html_tree
+  @spec find(binary() | html_tree(), css_selector()) :: html_tree
 
   def find(html, selector) when is_binary(html) do
     IO.warn(
@@ -237,7 +239,7 @@ defmodule Floki do
       [{"div", [{"id", "b"}, {"class", "name"}], []}]
 
   """
-  @spec attr(binary | html_tree, binary, binary, (binary -> binary)) :: html_tree
+  @spec attr(binary | html_tree, css_selector(), binary, (binary -> binary)) :: html_tree
 
   def attr(html_elem_tuple, selector, attribute_name, mutation) when is_tuple(html_elem_tuple) do
     attr([html_elem_tuple], selector, attribute_name, mutation)
@@ -338,7 +340,7 @@ defmodule Floki do
 
   @spec find_and_update(
           html_tree(),
-          Finder.selector(),
+          css_selector(),
           ({String.t(), [html_attribute()]} -> {String.t(), [html_attribute()]} | :delete)
         ) :: html_tree()
   def find_and_update(html_tree, selector, fun) do
@@ -361,7 +363,7 @@ defmodule Floki do
 
     tree
     |> HTMLTree.patch_nodes(operations_with_nodes)
-    |> HTMLTree.to_tuple()
+    |> HTMLTree.to_tuple_list()
   end
 
   @doc """
@@ -666,8 +668,8 @@ defmodule Floki do
 
   """
 
-  @spec filter_out(binary() | html_tree() | html_tag(), FilterOut.selector()) ::
-          html_tree() | html_tag()
+  @spec filter_out(html_node() | html_tree() | binary(), FilterOut.selector()) ::
+          html_node() | html_tree()
 
   def filter_out(html, selector) when is_binary(html) do
     IO.warn(

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -318,6 +318,24 @@ defmodule Floki do
       {"div", [{"data-name", "bar"}, {"class", "foo"}], ["text"]}
 
   """
+
+  @deprecated """
+  Use `traverse_and_update/2` instead. Example:
+
+      def map(html_tree_list, fun) do
+        traverse_and_update(html_tree_list, fn
+          {tag, attrs, children} ->
+            {tag, attrs} = fun.({tag, attrs})
+            {tag, attrs, children}
+
+          other ->
+            other
+        end)
+      end
+
+  """
+  def map(_html_tree_or_list, _fun)
+
   def map(html_tree_list, fun) when is_list(html_tree_list) do
     Enum.map(html_tree_list, &Finder.map(&1, fun))
   end

--- a/lib/floki/filter_out.ex
+++ b/lib/floki/filter_out.ex
@@ -25,6 +25,7 @@ defmodule Floki.FilterOut do
             HTMLTree.delete_node(tree, html_node)
           end)
 
+        # TODO: use "HTMLTree.to_tuple/1" directly
         html_as_tuples =
           new_tree.root_nodes_ids
           |> Enum.reverse()

--- a/lib/floki/filter_out.ex
+++ b/lib/floki/filter_out.ex
@@ -10,8 +10,8 @@ defmodule Floki.FilterOut do
 
   @spec filter_out(html_tree, selector) :: tuple | list
 
-  def filter_out(html_tree, type) when type in [:text, :comment] do
-    mapper(html_tree, type)
+  def filter_out(html_tree_or_node, type) when type in [:text, :comment] do
+    mapper(html_tree_or_node, type)
   end
 
   def filter_out(html_tree, selector) do

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -9,16 +9,13 @@ defmodule Floki.Finder do
   alias Floki.{HTMLTree, Selector}
   alias HTMLTree.HTMLNode
 
-  @type html_tree :: tuple | list
-  @type selector :: binary() | %Selector{} | [%Selector{}]
-
   # Find elements inside a HTML tree.
   # Second argument can be either a selector string, a selector struct or a list of selector structs.
 
-  @spec find(html_tree, selector) :: html_tree
+  @spec find(Floki.html_tree(), Floki.css_selector()) :: {HTMLTree.t(), [HTMLTree.HTMLNode.t()]}
 
-  def find([], _), do: {:empty_tree, []}
-  def find(html_as_string, _) when is_binary(html_as_string), do: {:empty_tree, []}
+  def find([], _), do: {%HTMLTree{}, []}
+  def find(html_as_string, _) when is_binary(html_as_string), do: {%HTMLTree{}, []}
 
   def find(html_tree, selector_as_string) when is_binary(selector_as_string) do
     selectors = get_selectors(selector_as_string)
@@ -33,7 +30,8 @@ defmodule Floki.Finder do
     find_selectors(html_tree, [selector])
   end
 
-  @spec map(html_tree, function) :: html_tree
+  @spec map(Floki.html_tree() | Floki.html_node(), function()) ::
+          Floki.html_tree() | Floki.html_node()
 
   def map({name, attrs, rest}, fun) do
     {new_name, new_attrs} = fun.({name, attrs})

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -234,9 +234,8 @@ defmodule Floki.HTMLTree do
     |> Map.put(new_node.parent_node_id, updated_parent)
   end
 
-  # This is useful when you want to update the HTML node in the tree.
-  def patch_nodes(html_tree, nodes_with_operations) do
-    Enum.reduce(nodes_with_operations, html_tree, fn node_with_op, tree ->
+  def patch_nodes(html_tree, operation_with_nodes) do
+    Enum.reduce(operation_with_nodes, html_tree, fn node_with_op, tree ->
       case node_with_op do
         {:update, node} ->
           put_in(tree.nodes[node.node_id], node)

--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -6,10 +6,16 @@ defmodule Floki.HTMLTree do
   # It is useful because keeps references for each node, and the possibility to
   # update the tree.
 
-  defstruct nodes: %{}, root_nodes_ids: [], node_ids: []
-
   alias Floki.HTMLTree
   alias Floki.HTMLTree.{HTMLNode, Text, Comment, IDSeeder}
+
+  defstruct nodes: %{}, root_nodes_ids: [], node_ids: []
+
+  @type t :: %__MODULE__{
+          nodes: %{optional(pos_integer()) => HTMLNode.t() | Text.t() | Comment.t()},
+          root_nodes_ids: [pos_integer()],
+          node_ids: [pos_integer()]
+        }
 
   def build({:comment, comment}) do
     %HTMLTree{
@@ -102,7 +108,7 @@ defmodule Floki.HTMLTree do
     do_delete(tree, [html_node], [])
   end
 
-  def to_tuple(html_tree) do
+  def to_tuple_list(html_tree) do
     html_tree.root_nodes_ids
     |> Enum.reverse()
     |> Enum.map(fn node_id ->

--- a/lib/floki/html_tree/comment.ex
+++ b/lib/floki/html_tree/comment.ex
@@ -3,4 +3,10 @@ defmodule Floki.HTMLTree.Comment do
 
   # Represents a comment inside an HTML tree with reference to its parent node id.
   defstruct content: "", node_id: nil, parent_node_id: nil
+
+  @type t :: %__MODULE__{
+          content: String.t(),
+          node_id: pos_integer(),
+          parent_node_id: pos_integer()
+        }
 end

--- a/lib/floki/html_tree/html_node.ex
+++ b/lib/floki/html_tree/html_node.ex
@@ -3,4 +3,11 @@ defmodule Floki.HTMLTree.HTMLNode do
 
   # Represents a HTML node with "references" to its children nodes ids and parent node id.
   defstruct type: "", attributes: [], children_nodes_ids: [], node_id: nil, parent_node_id: nil
+
+  @type t :: %__MODULE__{
+          type: String.t(),
+          attributes: [{String.t(), String.t()}],
+          node_id: pos_integer(),
+          parent_node_id: pos_integer()
+        }
 end

--- a/lib/floki/html_tree/text.ex
+++ b/lib/floki/html_tree/text.ex
@@ -3,4 +3,10 @@ defmodule Floki.HTMLTree.Text do
 
   # Represents a text node inside an HTML tree with reference to its parent node id.
   defstruct content: "", node_id: nil, parent_node_id: nil
+
+  @type t :: %__MODULE__{
+          content: String.t(),
+          node_id: pos_integer(),
+          parent_node_id: pos_integer()
+        }
 end

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -15,6 +15,16 @@ defmodule Floki.Selector do
             pseudo_classes: [],
             combinator: nil
 
+  @type t :: %__MODULE__{
+          id: String.t() | nil,
+          type: String.t() | nil,
+          classes: [String.t()],
+          attributes: [AttributeSelector.t()],
+          namespace: String.t() | nil,
+          pseudo_classes: [PseudoClass.t()],
+          combinator: Selector.Combinator.t() | nil
+        }
+
   defimpl String.Chars do
     def to_string(selector) do
       Enum.join([

--- a/lib/floki/selector/attribute_selector.ex
+++ b/lib/floki/selector/attribute_selector.ex
@@ -8,6 +8,12 @@ defmodule Floki.Selector.AttributeSelector do
 
   defstruct match_type: nil, attribute: nil, value: nil
 
+  @type t :: %__MODULE__{
+          match_type: :atom | nil,
+          attribute: String.t(),
+          value: String.t() | nil
+        }
+
   defimpl String.Chars do
     def to_string(selector) do
       "[#{selector.attribute}#{type(selector.match_type)}'#{selector.value}']"

--- a/lib/floki/selector/combinator.ex
+++ b/lib/floki/selector/combinator.ex
@@ -16,6 +16,11 @@ defmodule Floki.Selector.Combinator do
 
   defstruct match_type: nil, selector: nil
 
+  @type t :: %__MODULE__{
+          match_type: :atom,
+          selector: Floki.Selector.t()
+        }
+
   defimpl String.Chars do
     def to_string(combinator) do
       match_type =

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -9,6 +9,11 @@ defmodule Floki.Selector.PseudoClass do
   alias Floki.HTMLTree.{HTMLNode, Text}
   alias Floki.Selector.Functional
 
+  @type t :: %__MODULE__{
+          name: String.t(),
+          value: String.t() | [Floki.Selector.t()]
+        }
+
   defimpl String.Chars do
     def to_string(%{name: name, value: nil}) do
       ":#{name}"

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1177,7 +1177,7 @@ defmodule FlokiTest do
         |> document!()
 
       assert Floki.find_and_update(html, "span", fn
-               {"span", [{"class", "remove-me"}]} -> nil
+               {"span", [{"class", "remove-me"}]} -> :delete
                other -> other
              end) == [
                {

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1113,7 +1113,7 @@ defmodule FlokiTest do
   end
 
   describe "find_and_update/3" do
-    test "transform attributes from selected nodes" do
+    test "transforms attributes from selected nodes" do
       transformation = fn
         {"a", [{"href", href} | attrs]} ->
           {"a", [{"href", String.replace(href, "http://", "https://")} | attrs]}
@@ -1122,38 +1122,73 @@ defmodule FlokiTest do
           other
       end
 
-      result = Floki.find_and_update(document!(@html), ".content", transformation)
+      html_tree =
+        ~s(<div class="content"><a href="http://elixir-lang.org">Elixir</a><a href="http://github.com">GitHub</a></div>)
+        |> html_body()
+        |> document!()
 
-      hrefs_after =
-        result
-        |> Floki.find("a")
-        |> Floki.attribute("href")
+      result = Floki.find_and_update(html_tree, ".content a", transformation)
 
-      assert hrefs_after == ["https://google.com", "https://elixir-lang.org", "https://java.com"]
+      assert result == [
+               {"html", [],
+                [
+                  {"head", [], []},
+                  {"body", [],
+                   [
+                     {"div", [{"class", "content"}],
+                      [
+                        {"a", [{"href", "https://elixir-lang.org"}], ["Elixir"]},
+                        {"a", [{"href", "https://github.com"}], ["GitHub"]}
+                      ]}
+                   ]}
+                ]}
+             ]
     end
 
-    test "change the type of a given tag" do
+    test "changes the type of a given tag" do
       html =
         ~s(<div><span class="strong">Hello</span><span>world</span></div>)
         |> html_body()
-        |> Floki.parse_document!()
+        |> document!()
 
       assert Floki.find_and_update(html, "span.strong", fn
                {"span", attrs} -> {"strong", attrs}
                other -> other
-             end) == [{"strong", [{"class", "strong"}], ["Hello"]}]
+             end) == [
+               {
+                 "html",
+                 [],
+                 [
+                   {"head", [], []},
+                   {"body", [],
+                    [
+                      {"div", [],
+                       [{"strong", [{"class", "strong"}], ["Hello"]}, {"span", [], ["world"]}]}
+                    ]}
+                 ]
+               }
+             ]
     end
 
-    test "remove a node from results" do
+    test "removes a node from HTML tree" do
       html =
         ~s(<div><span class="remove-me">Hello</span><span>world</span></div>)
         |> html_body()
-        |> Floki.parse_document!()
+        |> document!()
 
       assert Floki.find_and_update(html, "span", fn
                {"span", [{"class", "remove-me"}]} -> nil
                other -> other
-             end) == [{"span", [], ["world"]}]
+             end) == [
+               {
+                 "html",
+                 [],
+                 [
+                   {"head", [], []},
+                   {"body", [], [{"div", [], [{"span", [], ["world"]}]}]}
+                 ]
+               }
+             ]
     end
   end
 


### PR DESCRIPTION
This PR deprecates the `Floki.map/2` function in in favour of `Floki.find_and_update/3` or `Enum.map/2`.
This follows the ideas of #286 

With `find_and_update/3` we can refactor functions like `Floki.filter_out/2` to use it.