### PR TITLE
Remove unused guards on CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           mix test.$PARSER
 
       - name: Run inch.report
+        if: matrix.elixir >= 1.7
         run: |-
           mix deps.get --only docs
           MIX_ENV=docs mix inch.report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Install dependencies
         run: |-
           apt-get update
+          apt-get -y install git
           if [ "$PARSER" = "fast_html" ]; then apt-get -y install build-essential cmake; fi
-          if [ "$PARSER" = "html5ever" ]; then apt-get -y install build-essential git curl; fi
+          if [ "$PARSER" = "html5ever" ]; then apt-get -y install build-essential curl; fi
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
@@ -52,7 +53,6 @@ jobs:
           mix test.$PARSER
 
       - name: Run inch.report
-        if: matrix.elixir >= 1.7
         run: |-
           mix deps.get --only docs
           MIX_ENV=docs mix inch.report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
         if: matrix.parser == 'html5ever'
 
       - name: Check format
-        if: (!startsWith(matrix.elixir, '1.6') && !startsWith(matrix.elixir, '1.7'))
         run: mix format --check-formatted
 
       - name: Run tests
@@ -53,7 +52,6 @@ jobs:
           mix test.$PARSER
 
       - name: Run inch.report
-        if: matrix.elixir >= 1.7
         run: |-
           mix deps.get --only docs
           MIX_ENV=docs mix inch.report

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Floki.Mixfile do
       {:ex_doc, "~> 0.23.0", only: :dev},
       {:credo, ">= 0.0.0", only: [:dev, :test]},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
-      {:inch_ex, ">= 0.0.0", only: :docs}
+      {:inch_ex, "~> 2.1.0-rc.1", only: :docs}
     ] ++ parsers
   end
 


### PR DESCRIPTION
The guard `matrix.elixir >= 1.7` prevented the `inch.report` task to run on all pipelines, since elixir `1.7` isn't list in the matrix I removed the guard and then the task started run.
I upgraded inch_ex because of known bug on version 2.0.0 when the beam file doesn't have the doc chunk and fixed at version 2.1.0-rc.1.