### PR TITLE
Replace IO.warn by Logger.info for deprecations

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -1,6 +1,8 @@
 defmodule Floki do
   alias Floki.{Finder, FilterOut, HTMLTree}
 
+  require Logger
+
   @moduledoc """
   Floki is a simple HTML parser that enables search for nodes using CSS selectors.
 
@@ -229,7 +231,7 @@ defmodule Floki do
   @spec find(binary() | html_tree() | html_node(), css_selector()) :: html_tree
 
   def find(html, selector) when is_binary(html) do
-    IO.warn(
+    Logger.info(
       "deprecation: parse the HTML with parse_document or parse_fragment before using find/2"
     )
 
@@ -267,7 +269,7 @@ defmodule Floki do
   end
 
   def attr(html, selector, attribute_name, mutation) when is_binary(html) do
-    IO.warn(
+    Logger.info(
       "deprecation: parse the HTML with parse_document or parse_fragment before using attr/4"
     )
 
@@ -577,7 +579,7 @@ defmodule Floki do
 
   @spec attribute(binary | html_tree | html_node, binary) :: list
   def attribute(html, attribute_name) when is_binary(html) do
-    IO.warn(
+    Logger.info(
       "deprecation: parse the HTML with parse_document or parse_fragment before using attribute/2"
     )
 
@@ -627,7 +629,7 @@ defmodule Floki do
   end
 
   defp parse_it(html) when is_binary(html) do
-    IO.warn(
+    Logger.info(
       "deprecation: parse the HTML with parse_document or parse_fragment before using text/2"
     )
 
@@ -666,7 +668,7 @@ defmodule Floki do
           html_node() | html_tree()
 
   def filter_out(html, selector) when is_binary(html) do
-    IO.warn(
+    Logger.info(
       "deprecation: parse the HTML with parse_document or parse_fragment before using filter_out/2"
     )
 

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1191,27 +1191,6 @@ defmodule FlokiTest do
     assert Floki.attribute(elements, "title") == []
   end
 
-  test "Floki.map/2 transforms nodes" do
-    elements = Floki.find(document!(@html), ".content")
-
-    transformation = fn
-      {"a", [{"href", x} | xs]} ->
-        {"a", [{"href", String.replace(x, "http://", "https://")} | xs]}
-
-      x ->
-        x
-    end
-
-    result = Floki.map(elements, transformation)
-
-    hrefs_after =
-      result
-      |> Floki.find("a")
-      |> Floki.attribute("href")
-
-    assert hrefs_after == ["https://google.com", "https://elixir-lang.org", "https://java.com"]
-  end
-
   describe "find_and_update/3" do
     test "transforms attributes from selected nodes" do
       transformation = fn


### PR DESCRIPTION
This allow the configuration of the logger level and the suppress of
undesirable messages in production.

Closes https://github.com/philss/floki/issues/329