### PR TITLE
Mochiweb - parse style tags as plaintext

### DIFF
--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -148,28 +148,33 @@ defmodule FlokiTest do
     end
 
     test "parse a HTML with tags that are plain text" do
-      validate_html = fn (tag) ->
-        {:ok, parsed} = tag
-        |> html_with_tag_that_should_not_have_children()
-        |> Floki.parse_document()
+      validate_html = fn tag ->
+        {:ok, parsed} =
+          tag
+          |> html_with_tag_that_should_not_have_children()
+          |> Floki.parse_document()
 
         current_parser = Application.get_env(:floki, :html_parser)
 
         case current_parser do
-          Mochiweb -> assert parsed ==
-              [
-                {"html", [],
-                [
-                  {"head", [], []},
-                  {"body", [],
-                    [
-                      {tag, [],
-                      ["this is not a <tag>\nthis is also </not> a tag\n and this is also not <a></a> tag"]}
-                    ]}
-                ]}
-              ]
+          Mochiweb ->
+            assert parsed ==
+                     [
+                       {"html", [],
+                        [
+                          {"head", [], []},
+                          {"body", [],
+                           [
+                             {tag, [],
+                              [
+                                "this is not a <tag>\nthis is also </not> a tag\n and this is also not <a></a> tag"
+                              ]}
+                           ]}
+                        ]}
+                     ]
 
-          _ -> {}
+          _ ->
+            {}
         end
       end
 
@@ -1511,6 +1516,10 @@ defmodule FlokiTest do
   end
 
   defp html_with_tag_that_should_not_have_children(tag) do
-    html_body("<#{tag}>this is not a <tag>\nthis is also </not> a tag\n and this is also not <a></a> tag</#{tag}>")
+    html_body(
+      "<#{tag}>this is not a <tag>\nthis is also </not> a tag\n and this is also not <a></a> tag</#{
+        tag
+      }>"
+    )
   end
 end


### PR DESCRIPTION
## Fixes #339

This is the fix for the issue.

At first I mentioned fixing the issue from the elixir side of things but I quickly realized it would be extremely ugly and probably inefficient.

So I hoped into the erlang code for mochiweb (Seeing erlang syntax for the first time was a bit overwhelming). After digging a bit I came across two function  `tokenize_script` and `tokenize_textarea`.

These functions provide the functionality we want, but for script and textarea tags. I wrote tests to make sure tags that are supposed to be plaintext get parsed correctly. And made them run on both style and script tags.  I was happy to see the tests only failed for the style tag but scripts are working just fine. So I created a function called `tokenize_style` which does what `tokenize_script` does but for style tags, and then implemented it.

✅ Tests passed

Great! The thing is there are more "plaintext" elements (eg title). I couldn't find a complete list of all of the elements.
The reason I did not implement a fix for the title tag as well is because the way mochiweb did it was to create a function for each tag (`tokenize_script`, `tokenize_textarea`). I am not sure why it did that instead of creating a function that works for all tags, perhaps for performance reasons. The thing I'm wondering is should I continue the tradition and create a function for each tag or try to create a function that works for all (which I am really not exited about since I can barely understand erlang)

Another thing is I made the new tests only run for Mochiweb since I could not get html5ever or fast_html to install/work properly, and since this PR is aimed at fixing Mochiweb this should not be a problem. Additionally no elixir code was changed, only Mochiweb code meaning the PR couldn't have broken html5ever/fasthtml functionality somehow.