### PR TITLE
Mochiweb - parse `title` tag as plaintext, Add `parser` ExUnit tags to skip tests based on current parser

### DIFF
--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -7,7 +7,9 @@ defmodule FlokiTest do
 
   @plain_text_tags [
     "script",
-    "style"
+    "style",
+    "title",
+    "textarea"
   ]
 
   @html """

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -147,6 +147,7 @@ defmodule FlokiTest do
       end
     end
 
+    @tag only_parser: Mochiweb
     test "parse a HTML with tags that are plain text" do
       validate_html = fn tag ->
         {:ok, parsed} =
@@ -154,28 +155,20 @@ defmodule FlokiTest do
           |> html_with_tag_that_should_not_have_children()
           |> Floki.parse_document()
 
-        current_parser = Application.get_env(:floki, :html_parser)
-
-        case current_parser do
-          Mochiweb ->
-            assert parsed ==
-                     [
-                       {"html", [],
-                        [
-                          {"head", [], []},
-                          {"body", [],
-                           [
-                             {tag, [],
-                              [
-                                "this is not a <tag>\nthis is also </not> a tag\n and this is also not <a></a> tag"
-                              ]}
-                           ]}
-                        ]}
-                     ]
-
-          _ ->
-            {}
-        end
+        assert parsed ==
+                 [
+                   {"html", [],
+                    [
+                      {"head", [], []},
+                      {"body", [],
+                       [
+                         {tag, [],
+                          [
+                            "this is not a <tag>\nthis is also </not> a tag\n and this is also not <a></a> tag"
+                          ]}
+                       ]}
+                    ]}
+                 ]
       end
 
       Enum.each(@plain_text_tags, validate_html)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,16 @@
+current_parser = Application.get_env(:floki, :html_parser)
+
 # fast_html uses a C-Node worker for parsing, so starting the application
 # is necessary for it to work
-if Application.get_env(:floki, :html_parser) == Floki.HTMLParser.FastHtml do
+if current_parser == Floki.HTMLParser.FastHtml do
   Application.ensure_all_started(:fast_html)
 end
+
+# Excluded tags can not be a list
+# which is why we need `except_parser` for cases where we want to include 2 parser
+ExUnit.configure(
+  exclude: [:only_parser, except_parser: current_parser],
+  include: [only_parser: nil, only_parser: current_parser]
+)
 
 ExUnit.start()


### PR DESCRIPTION
Hello again 😀
Title is pretty self explanatory...

In addition to making Mochiweb parse title tags as plaintext, 2 new ExUnit tags were added:
`only_parser` and `except_parser`.
Quoted from the commit description:
> Due to some ExUnit tag limitations we can not use `@tag parser [Parser1, Parser2]`. (ExUnit does not allow tags to be list if they are excluded/included)
That's why the `except_parser` tag was created to run a test for all parsers except a specific one. This works fine when we have only 3 parsers...

> if in the future Floki has more than 3 parsers and a test needs to include only 2, I think the best approach would be to create a test macro that will be used like:

```elixir
test_for_parsers [Parser1, Parser2] do
  ...
end
```