### PR TITLE
Require Elixir ~> 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test:
@@ -13,12 +17,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ["1.12.3", "1.8.2"]
-        otp: ["24.1", "22.3"]
+        elixir: ["1.13.3", "1.10.4"]
+        otp: ["24.3.2", "22.3.4"]
         parser: [fast_html, html5ever, mochiweb]
         exclude:
-          - elixir: "1.8.2"
-            otp: "24.1"
+          - elixir: "1.10.4"
+            otp: "24.3.2"
 
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +48,7 @@ jobs:
 
       - name: Check format
         run: mix format --check-formatted
-        if: matrix.elixir == '1.12.3'
+        if: matrix.elixir == '1.13.3'
 
       - name: Run test
         run: |-

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger, :console,
   format: "$metadata $message\n",

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Floki.Mixfile do
 
   @description "Floki is a simple HTML parser that enables search for nodes using CSS selectors."
   @source_url "https://github.com/philss/floki"
-  @version "0.32.1"
+  @version "0.33.0-dev"
 
   def project do
     [
@@ -11,7 +11,7 @@ defmodule Floki.Mixfile do
       name: "Floki",
       version: @version,
       description: @description,
-      elixir: "~> 1.8",
+      elixir: "~> 1.10",
       package: package(),
       erlc_paths: ["src", "gen"],
       deps: deps(),


### PR DESCRIPTION
This change drops support for Elixir 1.8 and 1.9 in order to use recent
versions for `html5ever`.