### PR TITLE
added insensitive case fl-icontains

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,10 @@ Here you find all the [CSS selectors](https://www.w3.org/TR/selectors/#selectors
 
 There are also some selectors based on non-standard specifications. They are:
 
-| Pattern              | Description                                         |
-|----------------------|-----------------------------------------------------|
-| E:fl-contains('foo') | an E element that contains "foo" inside a text node |
+| Pattern               | Description                                         |
+|-----------------------|-----------------------------------------------------|
+| E:fl-contains('foo')  | an E element that contains "foo" inside a text node |
+| E:fl-icontains('foo') | an E element that contains "foo" inside a text node (case insensitive) |
 
 ## Special thanks
 

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -210,6 +210,11 @@ defmodule Floki.Selector do
     PseudoClass.match_contains?(tree, html_node, pseudo_class)
   end
 
+  #Case insensitive contains
+  defp pseudo_class_match?(html_node, pseudo_class = %{name: "fl-icontains"}, tree) do
+    PseudoClass.match_icontains?(tree, html_node, pseudo_class)
+  end
+
   defp pseudo_class_match?(html_node, %{name: "root"}, tree) do
     PseudoClass.match_root?(html_node, tree)
   end

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -71,6 +71,18 @@ defmodule Floki.Selector.PseudoClass do
 
     res != nil
   end
+  #Case insensitive contains
+  def match_icontains?(tree, html_node, %__MODULE__{value: value}) do
+    res =
+      Enum.find(html_node.children_nodes_ids, fn id ->
+        case Map.get(tree.nodes, id) do
+          %Text{content: content} -> String.downcase(content) =~ String.downcase(value)
+          _ -> false
+        end
+      end)
+
+    res != nil
+  end
 
   defp match_position?(relative_position, value, name) do
     case value do

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1160,6 +1160,14 @@ defmodule FlokiTest do
            ]
   end
 
+  test "icontains pseudo-class" do
+    doc = document!(html_body(~s(<p>One</p><p>Two</p><div>nothing<b>42</b></div>)))
+
+    assert Floki.find(doc, "p:fl-icontains('two')") == [
+             {"p", [], ["Two"]}
+           ]
+  end
+
   test "contains psuedo-class with substring" do
     html =
       document!(


### PR DESCRIPTION
Hi,
I needed to add a case insensitive version of fl-contains. I called it fl-**i**contains. Some websites whose content are hand-written have some case discrepancy on text.
I could not test the whole "mix test" because I keep having troubles compiling html5ever/lexbor on my windows machine.
So I used the default parser and tested manually. 
I downcased the strings so it may not be optimal, but I am new to Elixir and I still have a lot to learn.
I will be glad for any suggestions, but please consider this feature as I find it necessary for what I want to do.
Thank you for your great work. I am enjoying this technology.
