### PR TITLE
user configurable self closing tags

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -1,7 +1,7 @@
 defmodule Floki.RawHTML do
   @moduledoc false
 
-  @self_closing_tags [
+  @default_self_closing_tags [
     "area",
     "base",
     "br",
@@ -13,12 +13,23 @@ defmodule Floki.RawHTML do
     "input",
     "keygen",
     "link",
+    "menuitem",
     "meta",
     "param",
     "source",
     "track",
     "wbr"
   ]
+
+  def default_self_closing_tags(), do: @default_self_closing_tags
+
+  def self_closing_tags do
+    custom_self_closing_tags = Application.get_env(:floki, :self_closing_tags)
+
+    if is_list(custom_self_closing_tags),
+      do: custom_self_closing_tags,
+      else: @default_self_closing_tags
+  end
 
   @encoder &HtmlEntities.encode/1
 
@@ -99,13 +110,19 @@ defmodule Floki.RawHTML do
   defp tag_with_attrs(type, attrs, children, padding),
     do: [leftpad(padding), "<", type, ?\s, tag_attrs(attrs) | close_open_tag(type, children)]
 
-  defp close_open_tag(type, []) when type in @self_closing_tags, do: "/>"
-  defp close_open_tag(_type, _), do: ">"
+  defp close_open_tag(type, children) do
+    case {type in self_closing_tags(), children} do
+      {true, []} -> "/>"
+      _ -> ">"
+    end
+  end
 
-  defp close_end_tag(type, [], _padding) when type in @self_closing_tags, do: ""
-
-  defp close_end_tag(type, _, padding),
-    do: [leftpad(padding), "</", type, ">", line_ending(padding)]
+  defp close_end_tag(type, children, padding) do
+    case {type in self_closing_tags(), children} do
+      {true, []} -> ""
+      _ -> [leftpad(padding), "</", type, ">", line_ending(padding)]
+    end
+  end
 
   defp build_attrs({attr, value}), do: [attr, "=\"", html_escape(value) | "\""]
   defp build_attrs(attr), do: attr

--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -119,7 +119,7 @@ defmodule Floki.RawHTML do
 
   defp close_end_tag(type, children, padding) do
     case {type in self_closing_tags(), children} do
-      {true, []} -> ""
+      {true, []} -> []
       _ -> [leftpad(padding), "</", type, ">", line_ending(padding)]
     end
   end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -250,6 +250,65 @@ defmodule FlokiTest do
     assert raw_html == "<link>www.example.com</link>"
   end
 
+  test "raw_html (with custom self closing tag without content and without attributes)" do
+    original_self_closing_tags = Application.get_env(:floki, :self_closing_tags)
+    Application.put_env(:floki, :self_closing_tags, ["shy"])
+
+    raw_html = Floki.raw_html({"shy", [], []})
+
+    assert raw_html == "<shy/>"
+
+    Application.put_env(:floki, :self_closing_tags, original_self_closing_tags)
+  end
+
+  test "raw_html (with custom self closing tag without content)" do
+    original_self_closing_tags = Application.get_env(:floki, :self_closing_tags)
+    Application.put_env(:floki, :self_closing_tags, ["download"])
+
+    raw_html = Floki.raw_html({"download", [{"href", "//www.example.com/file.zip"}], []})
+
+    assert raw_html == "<download href=\"//www.example.com/file.zip\"/>"
+
+    Application.put_env(:floki, :self_closing_tags, original_self_closing_tags)
+  end
+
+  test "raw_html (with custom self closing tag with content and with attribute)" do
+    original_self_closing_tags = Application.get_env(:floki, :self_closing_tags)
+    Application.put_env(:floki, :self_closing_tags, ["download"])
+
+    raw_html =
+      Floki.raw_html(
+        {"download", [{"href", "//www.example.com/file.zip"}], ["Download file.zip"]}
+      )
+
+    assert raw_html ==
+             "<download href=\"//www.example.com/file.zip\">Download file.zip</download>"
+
+    Application.put_env(:floki, :self_closing_tags, original_self_closing_tags)
+  end
+
+  test "raw_html (with custom self closing tag with content and without attribute)" do
+    original_self_closing_tags = Application.get_env(:floki, :self_closing_tags)
+    Application.put_env(:floki, :self_closing_tags, ["strike"])
+
+    raw_html = Floki.raw_html({"strike", [], ["stroke text"]})
+
+    assert raw_html == "<strike>stroke text</strike>"
+
+    Application.put_env(:floki, :self_closing_tags, original_self_closing_tags)
+  end
+
+  test "raw_html (with default self closing tag that isn't set while custom self closing tags are set must fail)" do
+    original_self_closing_tags = Application.get_env(:floki, :self_closing_tags)
+    Application.put_env(:floki, :self_closing_tags, ["page"])
+
+    raw_html = Floki.raw_html({"br", [], []})
+
+    assert raw_html != "<br/>"
+
+    Application.put_env(:floki, :self_closing_tags, original_self_closing_tags)
+  end
+
   test "raw_html (with script and style tags)" do
     tree = {
       "body",


### PR DESCRIPTION
Fixes [issue 405](https://github.com/philss/floki/issues/405).

Notice: Instead of just appending to the tag list, I have opted to expose the internal default tag list and replace it.

The reason for this is that in some specific xml dialects people would want to write they could replace `<img/>` with `<img>...<img/>` and floki would not be able to support that.

The trade-off here in terms of DX is that if you want to keep the standard html self closing tags you cannot just do:

```elixir
config :floki, :self_closing_tags, ["download"]
```

but you need to do

```elixir
config :floki, :self_closing_tags, ["tags", "you", "want"]
```

I am willing to document this and I hope that this solution passes your checks.

Please let me know if the way I have added unit tests is the the right approach for you.

p.s.: I have tested the feature in my small real world application where I am using a custom XMl dialect to allow a subset of html and extend it by some specific tags of which some are self-closing:

```elixir
# In my userland application `config/config.exs`
config :floki, :self_closing_tags, [
  "article",
  "br",
  "download",
  "hr",
  "media",
  "page",
  "shy",
  "space",
  "wbr"
]
```