### PR TITLE
Require Elixir ~> 1.11 and update CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ["1.13.3", "1.10.4"]
-        otp: ["24.3.2", "22.3.4"]
+        elixir: ["1.14.0", "1.11.4"]
+        otp: ["25.0.4", "22.3.4"]
         parser: [fast_html, html5ever, mochiweb]
         exclude:
-          - elixir: "1.10.4"
-            otp: "24.3.2"
+          - elixir: "1.14.0"
+            otp: "22.3.4"
+          - elixir: "1.11.4"
+            otp: "25.0.4"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: erlef/setup-beam@v1.9.0
+      - uses: erlef/setup-beam@v1.12
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+
+      - name: Check format
+        run: mix format --check-formatted
+        if: matrix.elixir == '1.14.0'
 
       - name: Install dependencies
         run: mix deps.get
@@ -45,10 +51,6 @@ jobs:
       - name: Install CMake
         uses: lukka/get-cmake@v3.21.2
         if: matrix.parser == 'fast_html'
-
-      - name: Check format
-        run: mix format --check-formatted
-        if: matrix.elixir == '1.13.3'
 
       - name: Run test
         run: |-

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule Floki.Mixfile do
       name: "Floki",
       version: @version,
       description: @description,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       package: package(),
       erlc_paths: ["src", "gen"],
       deps: deps(),
@@ -81,8 +81,7 @@ defmodule Floki.Mixfile do
         {{:"test.#{cli_name}", &test_with_parser(parser, &1)}, [cli_name | acc]}
       end)
 
-    aliases
-    |> Keyword.put(:test, &test_with_parser(cli_names, &1))
+    Keyword.put(aliases, :test, &test_with_parser(cli_names, &1))
   end
 
   defp test_with_parser(parser_cli_names, args) when is_list(parser_cli_names) do


### PR DESCRIPTION
This makes Floki compatible with the four latest versions of Elixir.