### PR TITLE
Allow attribute values to not be escaped

### DIFF
--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -391,6 +391,13 @@ defmodule FlokiTest do
     assert Floki.raw_html(tree, encode: false) == input
   end
 
+  test "raw_html encode: false does not encode attribute values" do
+    input = "<html><head></head><body class=\"1 > 0\">< \"test\" ></body></html>"
+    tree = document!(input)
+
+    assert Floki.raw_html(tree, encode: false) == input
+  end
+
   test "raw_html pretty with doctype" do
     html = """
       <!doctype html>


### PR DESCRIPTION
Oi @philss 

Thanks for your hard work on Floki, it's a great package, we use it in production and it works really well!

I found a small issue when using the `raw_html` function with the `encode: false` option.
On the app I'm working on, we allow users to configure html blocks programatically using the [liquid language](https://shopify.github.io/liquid/). We allow them to use liquid in the content of an HTML tag as well as on the attribute values.

This means that users can end up configuring an element that will look like the following in Floki:

```
{"a",
 [
   {"href", "{%if 1 > 0 %}\nhttp://www.google.com/\n{%endif%}"},
   {"class", "block-button block-button--solid block-button--sm"},
   {"style",
    "background-color: {{ vars.branding.primary_color | default: default_primary_color }}; border-radius: 6px; color: {{ vars.branding.primary_color_contrast | default: default_primary_color_contrast }};"},
   {"target", "_blank"}
 ], ["\n    A Button \n  "]}
 ```

The issue I'm seeing happens when we try to convert elements like the one above into HTML using `Floki.raw_html(encode: false)`. It was my expectation that attribute values wouldn't be encoded/escaped when the `encode` option was set as false.

As the code stands today, Floki always escapes the values of the attributes.
This PR attempts a very raw implementation of not encoding/escaping the attribute values if the `encode` option is set to `false`. So on the example above, the `>` character always get converted to `&gt`, which is not the behavior we are aiming for.

I'm very much open to update this implementation in anyway you see fit in order to support a way in which attribute values are left as is.

Again, thanks for taking the time to maintain Floki, and looking forward to your response with guidance on how to proceed with this.

Cheers!