### PR TITLE
Fix dialyzer issues with Floki.text/1

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -502,7 +502,7 @@ defmodule Floki do
 
   """
 
-  @spec text(html_tree | binary) :: binary
+  @spec text(html_tree | html_node | binary) :: binary
 
   def text(html, opts \\ [deep: true, js: false, style: true, sep: ""]) do
     cleaned_html_tree =


### PR DESCRIPTION
If you pass a node directly, you'll get an error like

```
The function call will not succeed.

Floki.text(_block :: {<<_::8>>, binary() | [{binary(), binary()}], [any()]})

breaks the contract
(html_tree() | binary()) :: binary()
```