### PR TITLE
Parse escaped colons in class names correctly

### DIFF
--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -20,6 +20,7 @@ Rules.
 {SYMBOL}                             : {token, {TokenChars, TokenLine}}.
 #{IDENTIFIER}                        : {token, {hash, TokenLine, tail(TokenChars)}}.
 \.{IDENTIFIER}                       : {token, {class, TokenLine, tail(TokenChars)}}.
+\.{IDENTIFIER}\\:{IDENTIFIER}        : {token, {class, TokenLine, tail(TokenChars)}}.
 \:{NOT}\(                            : {token, {pseudo_not, TokenLine}}.
 \:{IDENTIFIER}                       : {token, {pseudo, TokenLine, tail(TokenChars)}}.
 \({INT}\)                            : {token, {pseudo_class_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.

--- a/test/floki/selector/parser_test.exs
+++ b/test/floki/selector/parser_test.exs
@@ -22,6 +22,14 @@ defmodule Floki.Selector.ParserTest do
     end
   end
 
+  test "escaped colons in class names" do 
+    tokens = tokenize("a.xs\\:red-500")
+
+    assert Parser.parse(tokens) == [
+      %Selector{type: "a", classes: ["xs\\:red-500"], pseudo_classes: []}
+    ]
+  end
+
   test "multiple selectors" do
     tokens = tokenize("ol, ul")
 

--- a/test/floki/selector/parser_test.exs
+++ b/test/floki/selector/parser_test.exs
@@ -22,12 +22,12 @@ defmodule Floki.Selector.ParserTest do
     end
   end
 
-  test "escaped colons in class names" do 
+  test "escaped colons in class names" do
     tokens = tokenize("a.xs\\:red-500")
 
     assert Parser.parse(tokens) == [
-      %Selector{type: "a", classes: ["xs\\:red-500"], pseudo_classes: []}
-    ]
+             %Selector{type: "a", classes: ["xs\\:red-500"], pseudo_classes: []}
+           ]
   end
 
   test "multiple selectors" do


### PR DESCRIPTION
This pull requests adds an extra rule in the parser in order to prevent escaped class names (`a.xs\\:red-500`) from being parsed as  pseudo selectors.

Closes #411