### PR TITLE
Add `include_inputs?` option to Floki.text

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -482,7 +482,7 @@ defmodule Floki do
       iex> Floki.text({"div", [], [{"script", [], ["hello"]}, " world"]})
       " world"
 
-      iex> Floki.text([{"input", [{"type", "date"}, {"value", "2017-06-01"}], []}], include_inputs?: true)
+      iex> Floki.text([{"input", [{"type", "date"}, {"value", "2017-06-01"}], []}], include_inputs: true)
       "2017-06-01"
 
       iex> Floki.text({"div", [], [{"script", [], ["hello"]}, " world"]}, js: true)

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -482,6 +482,9 @@ defmodule Floki do
       iex> Floki.text({"div", [], [{"script", [], ["hello"]}, " world"]})
       " world"
 
+      iex> Floki.text([{"input", [{"type", "date"}, {"value", "2017-06-01"}], []}], include_inputs?: true)
+      "2017-06-01"
+
       iex> Floki.text({"div", [], [{"script", [], ["hello"]}, " world"]}, js: true)
       "hello world"
 
@@ -504,7 +507,7 @@ defmodule Floki do
 
   @spec text(html_tree | html_node | binary) :: binary
 
-  def text(html, opts \\ [deep: true, js: false, style: true, sep: ""]) do
+  def text(html, opts \\ [deep: true, js: false, style: true, sep: "", include_inputs?: false]) do
     cleaned_html_tree =
       html
       |> parse_it()
@@ -518,8 +521,8 @@ defmodule Floki do
       end
 
     case opts[:sep] do
-      nil -> search_strategy.get(cleaned_html_tree)
-      sep -> search_strategy.get(cleaned_html_tree, sep)
+      nil -> search_strategy.get(cleaned_html_tree, "", opts[:include_inputs?])
+      sep -> search_strategy.get(cleaned_html_tree, sep, opts[:include_inputs])
     end
   end
 

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -507,7 +507,7 @@ defmodule Floki do
 
   @spec text(html_tree | html_node | binary) :: binary
 
-  def text(html, opts \\ [deep: true, js: false, style: true, sep: "", include_inputs?: false]) do
+  def text(html, opts \\ [deep: true, js: false, style: true, sep: "", include_inputs: false]) do
     cleaned_html_tree =
       html
       |> parse_it()

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -521,7 +521,7 @@ defmodule Floki do
       end
 
     case opts[:sep] do
-      nil -> search_strategy.get(cleaned_html_tree, "", opts[:include_inputs?])
+      nil -> search_strategy.get(cleaned_html_tree, "", opts[:include_inputs])
       sep -> search_strategy.get(cleaned_html_tree, sep, opts[:include_inputs])
     end
   end

--- a/lib/floki/deep_text.ex
+++ b/lib/floki/deep_text.ex
@@ -6,25 +6,35 @@ defmodule Floki.DeepText do
 
   @type html_tree :: tuple | list
 
-  @spec get(html_tree, binary) :: binary
+  @spec get(html_tree, binary, boolean) :: binary
 
-  def get(html_tree, sep \\ "") do
-    get_text(html_tree, "", sep)
+  def get(html_tree, sep \\ "", include_inputs? \\ false)
+
+  def get(html_tree, sep, include_inputs?) do
+    get_text(html_tree, "", sep, include_inputs?)
   end
 
-  defp get_text(text, "", _sep) when is_binary(text), do: text
-  defp get_text(text, acc, sep) when is_binary(text), do: Enum.join([acc, text], sep)
+  defp get_text(text, "", _sep, _) when is_binary(text), do: text
+  defp get_text(text, acc, sep, _) when is_binary(text), do: Enum.join([acc, text], sep)
 
-  defp get_text(nodes, acc, sep) when is_list(nodes) do
+  defp get_text(nodes, acc, sep, include_inputs?) when is_list(nodes) do
     Enum.reduce(nodes, acc, fn child, istr ->
-      get_text(child, istr, sep)
+      get_text(child, istr, sep, include_inputs?)
     end)
   end
 
-  defp get_text({:comment, _}, acc, _), do: acc
-  defp get_text({"br", _, _}, acc, _), do: acc <> "\n"
+  defp get_text({:comment, _}, acc, _, _), do: acc
+  defp get_text({"br", _, _}, acc, _, _), do: acc <> "\n"
 
-  defp get_text({_, _, nodes}, acc, sep) do
-    get_text(nodes, acc, sep)
+  defp get_text({"input", attrs, _}, acc, _, true) do
+    acc <> Floki.TextExtractor.extract_input_value(attrs)
+  end
+
+  defp get_text({"textarea", attrs, _}, acc, _, true) do
+    acc <> Floki.TextExtractor.extract_input_value(attrs)
+  end
+
+  defp get_text({_, _, nodes}, acc, sep, include_inputs?) do
+    get_text(nodes, acc, sep, include_inputs?)
   end
 end

--- a/lib/floki/text_extractor.ex
+++ b/lib/floki/text_extractor.ex
@@ -1,0 +1,42 @@
+defmodule Floki.TextExtractor do
+  @moduledoc false
+
+  @allowed_input_types [
+    nil,
+    "color",
+    "date",
+    "datetime-local",
+    "email",
+    "month",
+    "number",
+    "search",
+    "tel",
+    "text",
+    "time",
+    "url",
+    "week"
+  ]
+
+  def extract_input_value(attrs) do
+    type = Enum.find(attrs, &match?({"type", _}, &1))
+
+    case type do
+      {"type", t} ->
+        if t in @allowed_input_types do
+          extract_value(attrs)
+        else
+          ""
+        end
+
+      nil ->
+        extract_value(attrs)
+    end
+  end
+
+  defp extract_value(attrs) do
+    Enum.find_value(attrs, "", fn
+      {"value", v} -> v
+      _ -> nil
+    end)
+  end
+end

--- a/lib/floki/text_extractor.ex
+++ b/lib/floki/text_extractor.ex
@@ -2,7 +2,6 @@ defmodule Floki.TextExtractor do
   @moduledoc false
 
   @allowed_input_types [
-    nil,
     "color",
     "date",
     "datetime-local",
@@ -18,18 +17,12 @@ defmodule Floki.TextExtractor do
   ]
 
   def extract_input_value(attrs) do
-    type = Enum.find(attrs, &match?({"type", _}, &1))
+    {"type", t} = Enum.find(attrs, {"type", "text"}, &match?({"type", _}, &1))
 
-    case type do
-      {"type", t} ->
-        if t in @allowed_input_types do
-          extract_value(attrs)
-        else
-          ""
-        end
-
-      nil ->
-        extract_value(attrs)
+    if t in @allowed_input_types do
+      extract_value(attrs)
+    else
+      ""
     end
   end
 

--- a/test/floki/deep_text_test.exs
+++ b/test/floki/deep_text_test.exs
@@ -15,6 +15,30 @@ defmodule Floki.DeepTextTest do
     assert Floki.DeepText.get(node, " ") == "Google"
   end
 
+  test "extracts text from text input" do
+    html = "<input value='foo' />"
+    {:ok, node} = Floki.parse_document(html)
+
+    assert Floki.DeepText.get(node, " ", true) == "foo"
+  end
+
+  test "extracts text from textarea" do
+    html = "<textarea value='bar' />"
+    {:ok, node} = Floki.parse_document(html)
+
+    assert Floki.DeepText.get(node, " ", true) == "bar"
+  end
+
+  test "extracts text from nested inputs" do
+    node =
+      {"div", [],
+       [
+         {"input", [{"value", "bar"}], []}
+       ]}
+
+    assert Floki.DeepText.get(node, " ", true) == "bar"
+  end
+
   test "text from a list of deep nodes" do
     nodes = [
       {

--- a/test/floki/flat_text_test.exs
+++ b/test/floki/flat_text_test.exs
@@ -15,6 +15,28 @@ defmodule Floki.FlatTextTest do
     assert Floki.FlatText.get(node, " ") == "Elixir lang"
   end
 
+  test "extracts text from text input" do
+    node = {"input", [{"value", "foo"}], []}
+
+    assert Floki.FlatText.get(node, " ", true) == "foo"
+  end
+
+  test "extracts text from textarea" do
+    node = {"textarea", [{"value", "bar"}], []}
+
+    assert Floki.FlatText.get(node, " ", true) == "bar"
+  end
+
+  test "extracts text from nested inputs" do
+    node =
+      {"div", [],
+       [
+         {"input", [{"value", "bar"}], []}
+       ]}
+
+    assert Floki.FlatText.get(node, " ", true) == "bar"
+  end
+
   test "a blank string when the node does not have text in the same level" do
     node = {"div", [], [{"a", [], ["Something in a deeper node"]}]}
 


### PR DESCRIPTION
This pull request adds the `include_inputs?` option to the `Floki.text` function.

Example usage:
```elixir
iex(1)> Floki.text([{"input", [{"type", "date"}, {"value", "2017-06-01"}], []}], include_inputs?: true)
"2017-06-01"
```

Currently it will add into the resulting text all the values from a list of allowed inputs (excluding things such as checkboxes and radios)

Feel free to review and point any changes you would like @philss

Closes #391 