### PR TITLE
Remove override of `mix test` task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Run test
         run: |-
-          MIX_ENV=test mix test.${{ matrix.parser }}
+          MIX_ENV=test mix test_${{ matrix.parser }}

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,0 @@
-import Config
-
-config :logger, :console,
-  format: "$metadata $message\n",
-  metadata: [:module]
-
-config :floki, :html_parser, Floki.HTMLParser.Mochiweb

--- a/mix.exs
+++ b/mix.exs
@@ -65,15 +65,15 @@ defmodule Floki.Mixfile do
           |> List.last()
           |> Macro.underscore()
 
-        {{:"test.#{cli_name}", &test_with_parser(parser, &1)}, [cli_name | acc]}
+        {{:"test_#{cli_name}", &test_with_parser(parser, &1)}, [cli_name | acc]}
       end)
 
-    Keyword.put(aliases, :test, &test_with_parser(cli_names, &1))
+    Keyword.put(aliases, :test_all, &test_with_parser(cli_names, &1))
   end
 
   defp test_with_parser(parser_cli_names, args) when is_list(parser_cli_names) do
     Enum.each(parser_cli_names, fn cli_name ->
-      Mix.shell().cmd("mix test.#{cli_name} --color #{Enum.join(args, " ")}",
+      Mix.shell().cmd("mix test_#{cli_name} --color #{Enum.join(args, " ")}",
         env: [{"MIX_ENV", "test"}]
       )
     end)

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -116,7 +116,7 @@ defmodule FlokiTest do
                 ]}
              ] = parsed
 
-      current_parser = Application.get_env(:floki, :html_parser)
+      current_parser = Application.get_env(:floki, :html_parser, Mochiweb)
 
       case current_parser do
         Mochiweb ->

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,9 @@
-current_parser = Application.get_env(:floki, :html_parser)
+current_parser = Application.get_env(:floki, :html_parser, Floki.HTMLParser.Mochiweb)
+
+Application.put_env(:logger, :console,
+  format: "$metadata $message\n",
+  metadata: [:module]
+)
 
 # fast_html uses a C-Node worker for parsing, so starting the application
 # is necessary for it to work


### PR DESCRIPTION
Instead, create a new task named "test_all" to run all backends. Now the tests of each parser can be executed with `mix test_parser`, where "parser" can be "mochiweb", "fast_html" or "html5ever".