### PR TITLE
`find/2` input protection proposal.

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -78,9 +78,8 @@ defmodule Floki do
   @type css_selector :: String.t() | %Floki.Selector{} | [%Floki.Selector{}]
 
   defguard is_html_node(value)
-           when is_binary(value) or
-           is_list(value) or tuple_size(value) == 3 or
-                  (tuple_size(value) == 2 and elem(value, 0) in [:pi, :comment, :doctype])
+           when is_binary(value) or tuple_size(value) == 3 or
+                  (tuple_size(value) == 2 and elem(value, 0) in [:pi, :comment]) or (tuple_size(value) == 4 and elem(value, 0) == :doctype)
 
   @doc """
   Parses a HTML Document from a String.
@@ -286,7 +285,7 @@ defmodule Floki do
     end
   end
 
-  def find(html_tree_as_tuple, selector) when is_html_node(html_tree_as_tuple) do
+  def find(html_tree_as_tuple, selector) when is_list(html_tree_as_tuple) or is_html_node(html_tree_as_tuple) do
     {tree, results} = Finder.find(html_tree_as_tuple, selector)
 
     Enum.map(results, fn html_node -> HTMLTree.to_tuple(tree, html_node) end)

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -1,4 +1,5 @@
 defmodule Floki do
+  require Floki
   alias Floki.{Finder, FilterOut, HTMLTree}
 
   require Logger
@@ -76,6 +77,8 @@ defmodule Floki do
   @type html_tree :: [html_node()]
 
   @type css_selector :: String.t() | %Floki.Selector{} | [%Floki.Selector{}]
+
+  defguard is_html_node(value) when is_binary(value) or tuple_size(value) == 3 or (tuple_size(value) == 2 and elem(value, 0) in [:pi, :comment, :doctype])
 
   @doc """
   Parses a HTML Document from a String.
@@ -168,7 +171,7 @@ defmodule Floki do
   ## Options
 
     * `:attributes_as_maps` - Change the behaviour of the parser to return the attributes
-      as maps, instead of a list of `{"key", "value"}`. Remember that maps are no longer 
+      as maps, instead of a list of `{"key", "value"}`. Remember that maps are no longer
       ordered since OTP 26. Default to `false`.
 
     * `:html_parser` - The module of the backend that is responsible for parsing
@@ -212,7 +215,7 @@ defmodule Floki do
   ## Options
 
     * `:encode` - A boolean option to control if special HTML characters
-    should be encoded as HTML entities. Defaults to `true`. 
+    should be encoded as HTML entities. Defaults to `true`.
 
     You can also control the encoding behaviour at the application level via
     `config :floki, :encode_raw_html, false`
@@ -282,7 +285,7 @@ defmodule Floki do
     end
   end
 
-  def find(html_tree_as_tuple, selector) do
+  def find(html_tree_as_tuple, selector) when is_html_node(html_tree_as_tuple) or is_list(html_tree_as_tuple) do
     {tree, results} = Finder.find(html_tree_as_tuple, selector)
 
     Enum.map(results, fn html_node -> HTMLTree.to_tuple(tree, html_node) end)
@@ -511,7 +514,7 @@ defmodule Floki do
 
   ## Options
 
-    * `:deep` - A boolean option to control how deep the search for 
+    * `:deep` - A boolean option to control how deep the search for
       text is going to be. If `false`, only the level of the HTML node
       or the first level of the HTML document is going to be considered.
       Defaults to `true`.

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -1,5 +1,4 @@
 defmodule Floki do
-  require Floki
   alias Floki.{Finder, FilterOut, HTMLTree}
 
   require Logger
@@ -78,7 +77,10 @@ defmodule Floki do
 
   @type css_selector :: String.t() | %Floki.Selector{} | [%Floki.Selector{}]
 
-  defguard is_html_node(value) when is_binary(value) or tuple_size(value) == 3 or (tuple_size(value) == 2 and elem(value, 0) in [:pi, :comment, :doctype])
+  defguard is_html_node(value)
+           when is_binary(value) or
+           is_list(value) or tuple_size(value) == 3 or
+                  (tuple_size(value) == 2 and elem(value, 0) in [:pi, :comment, :doctype])
 
   @doc """
   Parses a HTML Document from a String.
@@ -272,7 +274,6 @@ defmodule Floki do
   """
 
   @spec find(binary() | html_tree() | html_node(), css_selector()) :: html_tree
-
   def find(html, selector) when is_binary(html) do
     Logger.info(
       "deprecation: parse the HTML with parse_document or parse_fragment before using find/2"
@@ -285,7 +286,7 @@ defmodule Floki do
     end
   end
 
-  def find(html_tree_as_tuple, selector) when is_html_node(html_tree_as_tuple) or is_list(html_tree_as_tuple) do
+  def find(html_tree_as_tuple, selector) when is_html_node(html_tree_as_tuple) do
     {tree, results} = Finder.find(html_tree_as_tuple, selector)
 
     Enum.map(results, fn html_node -> HTMLTree.to_tuple(tree, html_node) end)

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -3,6 +3,7 @@ defmodule FlokiTest do
 
   doctest Floki
 
+  require Floki
   alias Floki.HTMLParser.{Html5ever, Mochiweb, FastHtml}
 
   @plain_text_tags [
@@ -1851,6 +1852,33 @@ defmodule FlokiTest do
       |> hd()
 
     assert result == html
+  end
+
+  describe "is_html_node/1 guard" do
+    test "returns true when html_tag is passed" do
+      assert Floki.is_html_node({"div", [], []})
+    end
+
+    test "returns true when html_comment is passed" do
+      assert Floki.is_html_node({:comment, "Ok"})
+    end
+
+    test "returns true when html_doctype is passed" do
+      assert Floki.is_html_node({:doctype, "html", nil, nil})
+    end
+
+    test "returns true when html_declaration is passed" do
+      assert Floki.is_html_node({:pi, "xml", [{"version", "1.0"}]})
+    end
+
+    test "returns true when html_text is passed" do
+      assert Floki.is_html_node("I am html_text")
+    end
+
+    test "returns false when {:ok, val} / {:error, reason} is supplied" do
+      refute Floki.is_html_node({:ok, 1})
+      refute Floki.is_html_node({:error, :reason})
+    end
   end
 
   @tag only_parser: Mochiweb


### PR DESCRIPTION
Today I had an issue where I accidentally passed `{:ok, tree}` into the `find/2`. I think it might not be a bad idea to protect the input with a guard. People who can't read the docs like me might save some frustration.

This is purely proposal. If I get a green light for this I will make develop this PR properly.