### PR TITLE
Update raw_html.ex to handle :attributes_as_maps option

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -224,6 +224,9 @@ defmodule Floki.RawHTML do
   defp map_intersperse([head | rest], separator, mapper),
     do: [mapper.(head), separator | map_intersperse(rest, separator, mapper)]
 
+  defp map_intersperse(%{} = attrs, separator, mapper),
+    do: map_intersperse(Map.to_list(attrs), separator, mapper)
+
   defp leftpad(:noop), do: ""
   defp leftpad(%{pad: pad, depth: depth}), do: String.duplicate(pad, depth)
 

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -530,6 +530,23 @@ defmodule FlokiTest do
            """
   end
 
+  test "raw_html when :attributes_as_maps options was used to parse (new Floki v0.35.0)" do
+    html_string =
+      ~s(<div id="content"><p><a href="site" class="bar"><span>lol</span><img src="foo.png"/></a></p><br/></div>)
+
+    parsed = Floki.parse_document!(html_string, attributes_as_maps: true) 
+    
+    # no guarantee of attribute order from a map
+    recombined = 
+     case Floki.raw_html(parsed) do
+      "<div id=\"content\"><p ><a class=\"bar\" href=\"site\"><span >lol</span><img src=\"foo.png\"/></a></p><br /></div>" -> true
+      "<div id=\"content\"><p ><a href=\"site\" class=\"bar\"><span >lol</span><img src=\"foo.png\"/></a></p><br /></div>" -> true
+      _other -> false
+    end
+
+    assert recombined
+  end
+
   # Floki.find/2 - Classes
 
   test "find elements with a given class" do


### PR DESCRIPTION
When parsing using the new option :attributes_as_maps, I got errors when trying to convert back with the raw_html function.  This changes the Map into a list where the error occurs and continues regular processing.