### PR TITLE
Add :leex to Mix compilers

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,7 @@ defmodule Floki.Mixfile do
       elixir: "~> 1.12",
       package: package(),
       erlc_paths: ["src", "gen"],
+      compilers: [:leex] ++ Mix.compilers(),
       deps: deps(),
       aliases: aliases(),
       docs: docs(),


### PR DESCRIPTION
Before this patch on Elixir main:

    ~/src/floki[main]% mix compile --force
    warning: in order to compile .xrl files, you must add "compilers: [:leex] ++ Mix.compilers()" to the "def project" section of your mix.exs
      (mix 1.17.0-dev) lib/mix/tasks/compile.leex.ex:69: Mix.Tasks.Compile.Leex.preload/1
      (mix 1.17.0-dev) lib/mix/compilers/erlang.ex:66: Mix.Compilers.Erlang.compile/6
      (mix 1.17.0-dev) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
      (mix 1.17.0-dev) lib/mix/tasks/compile.all.ex:124: Mix.Tasks.Compile.All.run_compiler/2
      (mix 1.17.0-dev) lib/mix/tasks/compile.all.ex:104: Mix.Tasks.Compile.All.compile/4
      (mix 1.17.0-dev) lib/mix/tasks/compile.all.ex:93: Mix.Tasks.Compile.All.with_logger_app/2

    Compiling 1 file (.xrl)
    Compiling 2 files (.erl)
    Compiling 31 files (.ex)
    Generated floki app
