### PR TITLE
Enable parse of IO data html

### DIFF
--- a/lib/floki/html_parser/fast_html.ex
+++ b/lib/floki/html_parser/fast_html.ex
@@ -4,12 +4,12 @@ defmodule Floki.HTMLParser.FastHtml do
 
   @impl true
   def parse_document(html, args) do
-    execute_with_module(fn module -> module.decode(html, args) end)
+    execute_with_module(fn module -> module.decode(IO.chardata_to_string(html), args) end)
   end
 
   @impl true
   def parse_fragment(html, args) do
-    execute_with_module(fn module -> module.decode_fragment(html, args) end)
+    execute_with_module(fn module -> module.decode_fragment(IO.chardata_to_string(html), args) end)
   end
 
   @impl true

--- a/lib/floki/html_parser/html5ever.ex
+++ b/lib/floki/html_parser/html5ever.ex
@@ -7,7 +7,7 @@ defmodule Floki.HTMLParser.Html5ever do
   def parse_document(html, _args) do
     case Code.ensure_loaded(Html5ever) do
       {:module, module} ->
-        case apply(module, :parse, [html]) do
+        case apply(module, :parse, [IO.chardata_to_string(html)]) do
           {:ok, result} ->
             {:ok, result}
 

--- a/lib/floki/html_parser/mochiweb.ex
+++ b/lib/floki/html_parser/mochiweb.ex
@@ -6,7 +6,7 @@ defmodule Floki.HTMLParser.Mochiweb do
 
   @impl true
   def parse_document(html, args) do
-    html = "<#{@root_node}>#{html}</#{@root_node}>"
+    html = ["<#{@root_node}>", html, "</#{@root_node}>"]
     {@root_node, _, parsed} = :floki_mochi_html.parse(html, args)
 
     {:ok, parsed}

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -262,7 +262,7 @@ defmodule FlokiTest do
 
     raw_html = Floki.raw_html(document!(html))
 
-    assert raw_html == html
+    assert raw_html == IO.chardata_to_string(html)
 
     html_with_doctype = [
       {:doctype, "html", "", ""},
@@ -283,7 +283,7 @@ defmodule FlokiTest do
 
     parsed = document!(span_with_entities)
 
-    assert Floki.raw_html(parsed) == span_with_entities
+    assert Floki.raw_html(parsed) == IO.chardata_to_string(span_with_entities)
   end
 
   test "raw_html/1 with plain text" do
@@ -1858,7 +1858,7 @@ defmodule FlokiTest do
       end)
       |> Floki.raw_html()
 
-    assert result == expects
+    assert result == IO.chardata_to_string(expects)
   end
 
   test "changing attribute don't change the order of nodes" do
@@ -1986,7 +1986,7 @@ defmodule FlokiTest do
   end
 
   defp html_body(body) do
-    "<html><head></head><body>#{body}</body></html>"
+    ["<html><head></head><body>", body, "</body></html>"]
   end
 
   defp document!(html_string, opts \\ []) do


### PR DESCRIPTION
`parse_document` and `parse_fragment` declare in their spec that they support `iodata()`, but this format is not actually working today. 
This PR adds support to IO data on all parsers, which is useful specially on mochiweb, since it has to add a `<floki>` tag around the html.