### PR TITLE
Optimize RawHTML.build_attrs/2

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -131,10 +131,10 @@ defmodule Floki.RawHTML do
   end
 
   defp build_attrs({attr, value}, encoder) do
-    if Function.info(encoder) == Function.info(&Function.identity/1) do
-      [attr, "=\"", value | "\""]
-    else
+    if encoder == @encoder do
       [attr, "=\"", html_escape(value) | "\""]
+    else
+      [attr, "=\"", value | "\""]
     end
   end
 


### PR DESCRIPTION
While doing benchmarks on a Phoenix LiveView project, I saw that `build_attrs/2` spent a lot of time running `Function.info/1` to check if we wanted to skip the HTML.

This PR replaces `Function.info` a simple equals check to see if the value is the same `@encoder`.

`:fprof` results before

```
%                                                     CNT                           ACC                           OWN
[{ totals,                                           4183972,                     6249.692,                     6096.914}].  %%%
...
{[{{'Elixir.Floki.RawHTML','-tag_attrs/2-fun-0-',2},   10952,                     1101.148,                       43.927}],
 { {'Elixir.Floki.RawHTML',build_attrs,2},             10952,                     1101.148,                       43.927},     %
 [{{erlang,fun_info,1},                                21904,                      701.652,                       21.910},
  {{'Elixir.Floki.RawHTML',html_escape,1},             10952,                      355.450,                       10.954},
  {garbage_collect,                                      109,                        0.109,                        0.109},
  {suspend,                                               10,                        0.010,                        0.000}]}.

```

`:fprof` results after

```
%                                                     CNT                           ACC                           OWN        
[{ totals,                                           3698164,                     5472.400,                     5367.805}].  %%%
...
{[{{'Elixir.Floki.RawHTML','-tag_attrs/2-fun-0-',2},   10952,                      377.486,                       22.015}],
 { {'Elixir.Floki.RawHTML',build_attrs,2},             10952,                      377.486,                       22.015},     %
 [{{'Elixir.Floki.RawHTML',html_escape,1},             10948,                      355.356,                       10.951},
  {garbage_collect,                                       99,                        0.099,                        0.099},
  {suspend,                                               16,                        0.016,                        0.000}]}.

```