### PR TITLE
Optimize parse_flag

### DIFF
--- a/src/floki_mochi_html.erl
+++ b/src/floki_mochi_html.erl
@@ -166,14 +166,14 @@ tokens(B, S = #decoder{offset = O}, Acc) ->
     end.
 
 parse_flag({start_tag, B, _, false}) ->
-    case string:to_lower(binary_to_list(B)) of
-        "script" ->
+    case B of
+        <<"script">> ->
             script;
-        "style" ->
+        <<"style">> ->
             style;
-        "title" ->
+        <<"title">> ->
             title;
-        "textarea" ->
+        <<"textarea">> ->
             textarea;
         _ ->
             none


### PR DESCRIPTION
`tokenize_literal` already changes this value to lower case, so in `parse_flag`  we can do a binary pattern match directly instead of running lower case in this value again.