### PR TITLE
Restrict `HTMLParser` interface to only accept binaries

### DIFF
--- a/lib/floki/html_parser.ex
+++ b/lib/floki/html_parser.ex
@@ -25,7 +25,7 @@ defmodule Floki.HTMLParser do
   @default_parser Floki.HTMLParser.Mochiweb
 
   @typep result(success) :: {:ok, success} | {:error, String.t()}
-  @typep html :: binary() | iodata()
+  @typep html :: binary()
 
   @callback parse_document(html(), Keyword.t()) :: result(Floki.html_tree())
   @callback parse_fragment(html(), Keyword.t()) :: result(Floki.html_tree())

--- a/lib/floki/html_parser/fast_html.ex
+++ b/lib/floki/html_parser/fast_html.ex
@@ -3,13 +3,13 @@ defmodule Floki.HTMLParser.FastHtml do
   @moduledoc false
 
   @impl true
-  def parse_document(html, args) do
-    execute_with_module(fn module -> module.decode(IO.chardata_to_string(html), args) end)
+  def parse_document(html, args) when is_binary(html) do
+    execute_with_module(fn module -> module.decode(html, args) end)
   end
 
   @impl true
-  def parse_fragment(html, args) do
-    execute_with_module(fn module -> module.decode_fragment(IO.chardata_to_string(html), args) end)
+  def parse_fragment(html, args) when is_binary(html) do
+    execute_with_module(fn module -> module.decode_fragment(html, args) end)
   end
 
   @impl true

--- a/lib/floki/html_parser/html5ever.ex
+++ b/lib/floki/html_parser/html5ever.ex
@@ -4,10 +4,10 @@ defmodule Floki.HTMLParser.Html5ever do
   @moduledoc false
 
   @impl true
-  def parse_document(html, _args) do
+  def parse_document(html, _args) when is_binary(html) do
     case Code.ensure_loaded(Html5ever) do
       {:module, module} ->
-        case apply(module, :parse, [IO.chardata_to_string(html)]) do
+        case apply(module, :parse, [html]) do
           {:ok, result} ->
             {:ok, result}
 
@@ -22,15 +22,15 @@ defmodule Floki.HTMLParser.Html5ever do
 
   # NOTE: html5ever does not implement parse_fragment yet.
   @impl true
-  def parse_fragment(html, args), do: parse_document(html, args)
+  def parse_fragment(html, args) when is_binary(html), do: parse_document(html, args)
 
   @impl true
-  def parse_document_with_attributes_as_maps(html, _args) do
+  def parse_document_with_attributes_as_maps(html, _args) when is_binary(html) do
     apply(ensure_module!(), :parse_with_attributes_as_maps, [html])
   end
 
   @impl true
-  def parse_fragment_with_attributes_as_maps(html, _args) do
+  def parse_fragment_with_attributes_as_maps(html, _args) when is_binary(html) do
     apply(ensure_module!(), :parse_with_attributes_as_maps, [html])
   end
 

--- a/lib/floki/html_parser/mochiweb.ex
+++ b/lib/floki/html_parser/mochiweb.ex
@@ -5,8 +5,8 @@ defmodule Floki.HTMLParser.Mochiweb do
   @root_node "floki"
 
   @impl true
-  def parse_document(html, args) do
-    html = ["<#{@root_node}>", html, "</#{@root_node}>"]
+  def parse_document(html, args) when is_binary(html) do
+    html = "<#{@root_node}>" <> html <> "</#{@root_node}>"
     {@root_node, _, parsed} = :floki_mochi_html.parse(html, args)
 
     {:ok, parsed}
@@ -14,15 +14,15 @@ defmodule Floki.HTMLParser.Mochiweb do
 
   # NOTE: mochi_html cannot make a distinction of a fragment and document.
   @impl true
-  def parse_fragment(html, args), do: parse_document(html, args)
+  def parse_fragment(html, args) when is_binary(html), do: parse_document(html, args)
 
   @impl true
-  def parse_document_with_attributes_as_maps(html, args) do
+  def parse_document_with_attributes_as_maps(html, args) when is_binary(html) do
     parse_document(html, Keyword.put(args, :attributes_as_maps, true))
   end
 
   @impl true
-  def parse_fragment_with_attributes_as_maps(html, args) do
+  def parse_fragment_with_attributes_as_maps(html, args) when is_binary(html) do
     parse_document(html, Keyword.put(args, :attributes_as_maps, true))
   end
 end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1986,7 +1986,7 @@ defmodule FlokiTest do
   end
 
   defp html_body(body) do
-    ["<html><head></head><body>", body, "</body></html>"]
+    "<html><head></head><body>" <> body <> "</body></html>"
   end
 
   defp document!(html_string, opts \\ []) do


### PR DESCRIPTION
This makes the interfaces simplier. We don't need to support iodata for now yet.