### PR TITLE
Use list instead of regex for string split

### DIFF
--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -144,7 +144,7 @@ defmodule Floki.Selector do
   defp do_classes_matches?(nil, _classes), do: false
 
   defp do_classes_matches?(class_attr_value, classes) do
-    classes -- String.split(class_attr_value, [" ", "\t"]) == []
+    classes -- String.split(class_attr_value, [" ", "\t", "\n"]) == []
   end
 
   defp attributes_matches?(_node, []), do: true

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -144,7 +144,7 @@ defmodule Floki.Selector do
   defp do_classes_matches?(nil, _classes), do: false
 
   defp do_classes_matches?(class_attr_value, classes) do
-    classes -- String.split(class_attr_value, ~r/\s+/) == []
+    classes -- String.split(class_attr_value, [" ", "\t"]) == []
   end
 
   defp attributes_matches?(_node, []), do: true

--- a/lib/floki/selector/attribute_selector.ex
+++ b/lib/floki/selector/attribute_selector.ex
@@ -63,7 +63,7 @@ defmodule Floki.Selector.AttributeSelector do
     s.attribute
     |> get_value(attributes)
     # Splits by whitespaces ("a  b c" -> ["a", "b", "c"])
-    |> String.split(~r/\s+/)
+    |> String.split([" ", "\t"])
     |> Enum.any?(fn v -> String.downcase(v) == selector_value end)
   end
 
@@ -103,7 +103,7 @@ defmodule Floki.Selector.AttributeSelector do
 
   def match?(attributes, s = %AttributeSelector{match_type: :includes, value: value}) do
     get_value(s.attribute, attributes)
-    |> String.split(~r/\s+/)
+    |> String.split([" ", "\t"])
     |> Enum.any?(fn v -> v == value end)
   end
 

--- a/lib/floki/selector/attribute_selector.ex
+++ b/lib/floki/selector/attribute_selector.ex
@@ -63,7 +63,7 @@ defmodule Floki.Selector.AttributeSelector do
     s.attribute
     |> get_value(attributes)
     # Splits by whitespaces ("a  b c" -> ["a", "b", "c"])
-    |> String.split([" ", "\t"])
+    |> String.split([" ", "\t", "\n"])
     |> Enum.any?(fn v -> String.downcase(v) == selector_value end)
   end
 
@@ -103,7 +103,7 @@ defmodule Floki.Selector.AttributeSelector do
 
   def match?(attributes, s = %AttributeSelector{match_type: :includes, value: value}) do
     get_value(s.attribute, attributes)
-    |> String.split([" ", "\t"])
+    |> String.split([" ", "\t", "\n"])
     |> Enum.any?(fn v -> v == value end)
   end
 


### PR DESCRIPTION
Today the class and attribute selector are using String.split with a regex, but [using a list of separators instead of regex is faster](https://github.com/devonestes/fast-elixir#splitting-large-strings-code).

```
Name                    ips        average  deviation         median         99th %
pr                   668.99        1.49 ms    ±15.56%        1.43 ms        2.39 ms
today                528.96        1.89 ms    ±13.51%        1.81 ms        2.84 ms

Comparison: 
pr                   668.99
today                528.96 - 1.26x slower +0.40 ms

Memory usage statistics:

Name             Memory usage
pr                    1.92 MB
today                 2.09 MB - 1.08x memory usage +0.161 MB
```
```
read_file = fn name ->
  __ENV__.file
  |> Path.dirname()
  |> Path.join(name)
  |> File.read!()
end

html_input = read_file.("small.html")

[{"html", _, _} = html | _] = Floki.parse_document!(html_input)

Benchee.run(
  %{
    "bench" => fn -> Floki.Finder.find(html, ".mw-parser-output > p")  end
  },
  time: 5,
  memory_time: 2
)
```