### PR TITLE
Optimize HTMLTree.build

### DIFF
--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -31,83 +31,95 @@ defmodule Floki.HTMLTree do
     root_id = IDSeeder.seed([])
     root_node = %HTMLNode{type: tag, attributes: attrs, node_id: root_id}
 
-    tree =
+    {node_ids, nodes} =
       build_tree(
-        %HTMLTree{root_nodes_ids: [root_id], node_ids: [root_id], nodes: []},
+        [root_id],
+        [],
         children,
         root_node,
         []
       )
 
-    build_nodes_map(tree)
+    %HTMLTree{
+      root_nodes_ids: [root_id],
+      node_ids: node_ids,
+      nodes: Map.new(nodes)
+    }
   end
 
   def build(html_tuples) when is_list(html_tuples) do
     reducer = fn
-      {:pi, _, _}, tree ->
-        tree
+      {:pi, _, _}, state ->
+        state
 
-      {tag, attrs, children}, tree ->
-        root_id = IDSeeder.seed(tree.node_ids)
-
+      {tag, attrs, children}, {root_nodes_ids, node_ids, nodes} ->
+        root_id = IDSeeder.seed(node_ids)
         root_node = %HTMLNode{type: tag, attributes: attrs, node_id: root_id}
 
-        build_tree(
-          %{
-            tree
-            | node_ids: [root_id | tree.node_ids],
-              root_nodes_ids: [root_id | tree.root_nodes_ids]
-          },
-          children,
-          root_node,
-          []
-        )
+        root_nodes_ids = [root_id | root_nodes_ids]
+        node_ids = [root_id | node_ids]
 
-      text, tree when is_binary(text) ->
-        root_id = IDSeeder.seed(tree.node_ids)
+        {node_ids, nodes} =
+          build_tree(
+            node_ids,
+            nodes,
+            children,
+            root_node,
+            []
+          )
 
+        {root_nodes_ids, node_ids, nodes}
+
+      text, {root_nodes_ids, node_ids, nodes} when is_binary(text) ->
+        root_id = IDSeeder.seed(node_ids)
         root_node = %Text{content: text, node_id: root_id}
 
-        build_tree(
-          %{
-            tree
-            | node_ids: [root_id | tree.node_ids],
-              root_nodes_ids: [root_id | tree.root_nodes_ids]
-          },
-          [],
-          root_node,
-          []
-        )
+        root_nodes_ids = [root_id | root_nodes_ids]
+        node_ids = [root_id | node_ids]
 
-      {:comment, comment}, tree ->
-        root_id = IDSeeder.seed(tree.node_ids)
+        {node_ids, nodes} =
+          build_tree(
+            node_ids,
+            nodes,
+            [],
+            root_node,
+            []
+          )
 
+        {root_nodes_ids, node_ids, nodes}
+
+      {:comment, comment}, {root_nodes_ids, node_ids, nodes} ->
+        root_id = IDSeeder.seed(node_ids)
         root_node = %Comment{content: comment, node_id: root_id}
 
-        build_tree(
-          %{
-            tree
-            | node_ids: [root_id | tree.node_ids],
-              root_nodes_ids: [root_id | tree.root_nodes_ids]
-          },
-          [],
-          root_node,
-          []
-        )
+        root_nodes_ids = [root_id | root_nodes_ids]
+        node_ids = [root_id | node_ids]
 
-      _, tree ->
-        tree
+        {node_ids, nodes} =
+          build_tree(
+            node_ids,
+            nodes,
+            [],
+            root_node,
+            []
+          )
+
+        {root_nodes_ids, node_ids, nodes}
+
+      _, state ->
+        state
     end
 
-    tree = Enum.reduce(html_tuples, %HTMLTree{nodes: []}, reducer)
-    build_nodes_map(tree)
+    {root_nodes_ids, node_ids, nodes} = Enum.reduce(html_tuples, {[], [], []}, reducer)
+
+    %HTMLTree{
+      root_nodes_ids: root_nodes_ids,
+      node_ids: node_ids,
+      nodes: Map.new(nodes)
+    }
   end
 
   def build(_), do: %HTMLTree{}
-
-  defp build_nodes_map(tree) do
-    %{tree | nodes: Map.new(tree.nodes)}
-  end
 
   def delete_node(tree, html_node) do
     do_delete(tree, [html_node], [])
@@ -179,16 +191,16 @@ defmodule Floki.HTMLTree do
   defp get_ids_for_delete_stack(%HTMLNode{children_nodes_ids: ids}), do: ids
   defp get_ids_for_delete_stack(_), do: []
 
-  defp build_tree(tree, [], parent_node, []) do
-    %{tree | nodes: [{parent_node.node_id, parent_node} | tree.nodes]}
+  defp build_tree(node_ids, nodes, [], parent_node, []) do
+    {node_ids, [{parent_node.node_id, parent_node} | nodes]}
   end
 
-  defp build_tree(tree, [{:pi, _, _} | children], parent_node, stack) do
-    build_tree(tree, children, parent_node, stack)
+  defp build_tree(node_ids, nodes, [{:pi, _, _} | children], parent_node, stack) do
+    build_tree(node_ids, nodes, children, parent_node, stack)
   end
 
-  defp build_tree(tree, [{tag, attrs, child_children} | children], parent_node, stack) do
-    new_id = IDSeeder.seed(tree.node_ids)
+  defp build_tree(node_ids, nodes, [{tag, attrs, child_children} | children], parent_node, stack) do
+    new_id = IDSeeder.seed(node_ids)
 
     new_node = %HTMLNode{
       type: tag,
@@ -199,74 +211,72 @@ defmodule Floki.HTMLTree do
 
     parent_node = %{
       parent_node
-    | children_nodes_ids: [new_id | parent_node.children_nodes_ids]
+      | children_nodes_ids: [new_id | parent_node.children_nodes_ids]
     }
 
     build_tree(
-      %{tree | node_ids: [new_id | tree.node_ids]},
+      [new_id | node_ids],
+      nodes,
       child_children,
       new_node,
       [{parent_node, children} | stack]
     )
   end
 
-  defp build_tree(tree, [{:comment, comment} | children], parent_node, stack) do
-    new_id = IDSeeder.seed(tree.node_ids)
+  defp build_tree(node_ids, nodes, [{:comment, comment} | children], parent_node, stack) do
+    new_id = IDSeeder.seed(node_ids)
     new_node = %Comment{content: comment, node_id: new_id, parent_node_id: parent_node.node_id}
 
-    {tree, parent_node} = put_new_node(tree, new_node, parent_node)
+    parent_node = %{
+      parent_node
+      | children_nodes_ids: [new_id | parent_node.children_nodes_ids]
+    }
 
     build_tree(
-      tree,
+      [new_id | node_ids],
+      [{new_id, new_node} | nodes],
       children,
       parent_node,
       stack
     )
   end
 
-  defp build_tree(tree, [text | children], parent_node, stack) when is_binary(text) do
-    new_id = IDSeeder.seed(tree.node_ids)
+  defp build_tree(node_ids, nodes, [text | children], parent_node, stack) when is_binary(text) do
+    new_id = IDSeeder.seed(node_ids)
     new_node = %Text{content: text, node_id: new_id, parent_node_id: parent_node.node_id}
 
-    {tree, parent_node} = put_new_node(tree, new_node, parent_node)
+    parent_node = %{
+      parent_node
+      | children_nodes_ids: [new_id | parent_node.children_nodes_ids]
+    }
 
     build_tree(
-      tree,
+      [new_id | node_ids],
+      [{new_id, new_node} | nodes],
       children,
       parent_node,
       stack
     )
   end
 
-  defp build_tree(tree, [_other | children], parent_node, stack) do
-    build_tree(tree, children, parent_node, stack)
+  defp build_tree(node_ids, nodes, [_other | children], parent_node, stack) do
+    build_tree(node_ids, nodes, children, parent_node, stack)
   end
 
-  defp build_tree(tree, [], parent_node, [{next_parent_node, next_parent_children} | stack]) do
-
+  defp build_tree(
+         node_ids,
+         nodes,
+         [],
+         parent_node,
+         [{next_parent_node, next_parent_children} | stack]
+       ) do
     build_tree(
-      %{tree | nodes: [{parent_node.node_id, parent_node} | tree.nodes]},
+      node_ids,
+      [{parent_node.node_id, parent_node} | nodes],
       next_parent_children,
       next_parent_node,
       stack
     )
-  end
-
-  defp put_new_node(tree, new_node, parent_node) do
-    new_node_id = new_node.node_id
-
-    updated_tree = %{
-      tree
-      | nodes: [{new_node_id, new_node} | tree.nodes],
-        node_ids: [new_node_id | tree.node_ids]
-    }
-
-    updated_parent_node = %{
-      parent_node
-      | children_nodes_ids: [new_node_id | parent_node.children_nodes_ids]
-    }
-
-    {updated_tree, updated_parent_node}
   end
 
   def patch_nodes(html_tree, operation_with_nodes) do


### PR DESCRIPTION
Today when HTMLTree.build is called, after each element is build, the parent node children_nodes_ids list is updated, and the parent node and current node are put on tree.nodes map. This repeated updates ends up being quite costly on both memory and CPU.

This PR applies multiple changes to this module to significantly reduce the tree building cost:
- Add parent_node to tree.nodes only after all it's children are build and added to children_nodes_ids - benchmark reduced-updates
- During build, instead of storing the nodes as map and updating it on each built node, store the node as list of {node_id, node}, and build the map only at the end - benchmark reduced-updates
- Instead of using HTMLTree on build_tree calls, use node_ids and nodes values directly - benchmark pr

```
##### With input big #####
Name                      ips        average  deviation         median         99th %
pr                      61.20       16.34 ms    ±40.16%       15.42 ms       31.98 ms
reduced-updates         34.61       28.89 ms    ±17.36%       29.11 ms       36.52 ms
today                   12.61       79.30 ms    ±26.62%       83.80 ms      116.42 ms

Comparison:
pr                      61.20
reduced-updates         34.61 - 1.77x slower +12.55 ms
today                   12.61 - 4.85x slower +62.96 ms

Memory usage statistics:

Name               Memory usage
pr                      7.72 MB
reduced-updates        10.95 MB - 1.42x memory usage +3.22 MB
today                  35.95 MB - 4.65x memory usage +28.23 MB

**All measurements for memory usage were the same**

##### With input medium #####
Name                      ips        average  deviation         median         99th %
pr                     443.81        2.25 ms    ±20.15%        2.37 ms        3.68 ms
reduced-updates        149.36        6.70 ms    ±20.07%        6.01 ms       10.76 ms
today                   55.43       18.04 ms    ±37.78%       20.38 ms       29.83 ms

Comparison:
pr                     443.81
reduced-updates        149.36 - 2.97x slower +4.44 ms
today                   55.43 - 8.01x slower +15.79 ms

Memory usage statistics:

Name               Memory usage
pr                      2.21 MB
reduced-updates         3.43 MB - 1.55x memory usage +1.22 MB
today                   9.96 MB - 4.51x memory usage +7.75 MB

**All measurements for memory usage were the same**

##### With input small #####
Name                      ips        average  deviation         median         99th %
pr                     879.27        1.14 ms   ±103.59%        0.39 ms        4.14 ms
reduced-updates        655.86        1.52 ms    ±85.16%        0.52 ms        4.46 ms
today                  308.46        3.24 ms    ±24.74%        2.99 ms        6.37 ms

Comparison:
pr                     879.27
reduced-updates        655.86 - 1.34x slower +0.39 ms
today                  308.46 - 2.85x slower +2.10 ms

Memory usage statistics:

Name               Memory usage
pr                    507.54 KB
reduced-updates       664.93 KB - 1.31x memory usage +157.39 KB
today                1757.59 KB - 3.46x memory usage +1250.05 KB
```

```elixir
read_file = fn name ->
  [{"html", _, _} = html | _] =
    __ENV__.file
    |> Path.dirname()
    |> Path.join(name)
    |> File.read!()
    |> Floki.parse_document!()

  html
end

inputs = %{
  "big" => read_file.("big.html"),
  "medium" => read_file.("medium.html"),
  "small" => read_file.("small.html")
}

Benchee.run(
  %{
    "bench" => fn html -> Floki.HTMLTree.build(html) end
  },
  inputs: inputs,
  time: 5,
  memory_time: 2
)
```