### PR TITLE
Call self_closing_tags only once on raw_html

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -47,7 +47,7 @@ defmodule Floki.RawHTML do
         _ -> :noop
       end
 
-    self_closing_tags = self_closing_tags()
+    self_closing_tags = MapSet.new(self_closing_tags())
 
     IO.iodata_to_binary(build_raw_html(html_tree, [], encoder, padding, self_closing_tags))
   end
@@ -143,7 +143,7 @@ defmodule Floki.RawHTML do
     ]
 
   defp close_open_tag(type, [], self_closing_tags) do
-    if type in self_closing_tags do
+    if MapSet.member?(self_closing_tags, type) do
       "/>"
     else
       ">"
@@ -153,7 +153,7 @@ defmodule Floki.RawHTML do
   defp close_open_tag(_type, _children, _self_closing_tags), do: ">"
 
   defp close_end_tag(type, [], padding, self_closing_tags) do
-    if type in self_closing_tags do
+    if MapSet.member?(self_closing_tags, type) do
       []
     else
       [leftpad(padding), "</", type, ">", line_ending(padding)]

--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -47,7 +47,7 @@ defmodule Floki.RawHTML do
         _ -> :noop
       end
 
-    self_closing_tags = MapSet.new(self_closing_tags())
+    self_closing_tags = self_closing_tags()
 
     IO.iodata_to_binary(build_raw_html(html_tree, [], encoder, padding, self_closing_tags))
   end
@@ -143,7 +143,7 @@ defmodule Floki.RawHTML do
     ]
 
   defp close_open_tag(type, [], self_closing_tags) do
-    if MapSet.member?(self_closing_tags, type) do
+    if type in self_closing_tags do
       "/>"
     else
       ">"
@@ -153,7 +153,7 @@ defmodule Floki.RawHTML do
   defp close_open_tag(_type, _children, _self_closing_tags), do: ">"
 
   defp close_end_tag(type, [], padding, self_closing_tags) do
-    if MapSet.member?(self_closing_tags, type) do
+    if type in self_closing_tags do
       []
     else
       [leftpad(padding), "</", type, ">", line_ending(padding)]


### PR DESCRIPTION
`self_closing_tags` is not a slow function, but today it is called thousands of times while generating the raw html, which ends up causing a significant performance impact. 

This PR modifies the RawHTML module to call `self_closing_tags()` only once on `raw_html`, sending the value as params to the other functions. `raw_html` also converts closing tags to MapSet to help speed up the check .

```
##### With input big #####
Name                 ips        average  deviation         median         99th %
bench (pr)         61.60       16.23 ms    ±14.47%       15.99 ms       21.96 ms
bench              39.96       25.03 ms     ±9.18%       24.86 ms       31.23 ms

Comparison: 
bench (pr)         61.60
bench              39.96 - 1.54x slower +8.79 ms

Memory usage statistics:

Name          Memory usage
bench (pr)         8.47 MB
bench              9.49 MB - 1.12x memory usage +1.02 MB

**All measurements for memory usage were the same**

##### With input medium #####
Name                 ips        average  deviation         median         99th %
bench (pr)        197.42        5.07 ms    ±24.27%        4.80 ms        9.11 ms
bench             124.30        8.05 ms    ±14.06%        7.77 ms       11.08 ms

Comparison: 
bench (pr)        197.42
bench             124.30 - 1.59x slower +2.98 ms

Memory usage statistics:

Name          Memory usage
bench (pr)         2.95 MB
bench              3.31 MB - 1.12x memory usage +0.36 MB

**All measurements for memory usage were the same**

##### With input small #####
Name                 ips        average  deviation         median         99th %
bench (pr)        1.26 K        0.79 ms    ±10.28%        0.77 ms        1.10 ms
bench             0.74 K        1.35 ms    ±10.38%        1.30 ms        1.83 ms

Comparison: 
bench (pr)        1.26 K
bench             0.74 K - 1.70x slower +0.55 ms

Memory usage statistics:

Name          Memory usage
bench (pr)       645.78 KB
bench            720.79 KB - 1.12x memory usage +75.01 KB

**All measurements for memory usage were the same**
```
```
read_file = fn name ->
  __ENV__.file
  |> Path.dirname()
  |> Path.join(name)
  |> File.read!()
  |> Floki.parse_document!()
end

inputs = %{
  "big" => read_file.("big.html"),
  "medium" => read_file.("medium.html"),
  "small" => read_file.("small.html")
}

Benchee.run(
  %{
    "bench" => &Floki.raw_html/1
  },
  time: 10,
  inputs: inputs,
  memory_time: 2,
)
```