### PR TITLE
Use stack on Finder

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -28,17 +28,6 @@ defmodule Floki.Finder do
     find_selectors(html_tree, selectors)
   end
 
-  @spec map(Floki.html_tree() | Floki.html_node(), function()) ::
-          Floki.html_tree() | Floki.html_node()
-
-  def map({name, attrs, rest}, fun) do
-    {new_name, new_attrs} = fun.({name, attrs})
-
-    {new_name, new_attrs, Enum.map(rest, &map(&1, fun))}
-  end
-
-  def map(other, _fun), do: other
-
   defp find_selectors(html_tuple_or_list, selectors) do
     tree = HTMLTree.build(html_tuple_or_list)
 
@@ -165,4 +154,15 @@ defmodule Floki.Finder do
         []
     end
   end
+
+  @spec map(Floki.html_tree() | Floki.html_node(), function()) ::
+          Floki.html_tree() | Floki.html_node()
+
+  def map({name, attrs, rest}, fun) do
+    {new_name, new_attrs} = fun.({name, attrs})
+
+    {new_name, new_attrs, Enum.map(rest, &map(&1, fun))}
+  end
+
+  def map(other, _fun), do: other
 end

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -68,49 +68,30 @@ defmodule Floki.Finder do
     html_node = get_node(node_id, tree)
 
     if Selector.match?(html_node, selector, tree) do
-      traverse_with(combinator, html_node, tree, acc)
+      nodes = get_selector_nodes(combinator, html_node, tree)
+      traverse_with(combinator.selector, nodes, tree, acc)
     else
       acc
     end
   end
 
-  defp traverse_with(
-         %Selector.Combinator{match_type: :child, selector: s},
-         html_node,
-         tree,
-         acc
-       ) do
-    traverse_with(s, Enum.reverse(html_node.children_nodes_ids), tree, acc)
+  defp get_selector_nodes(%Selector.Combinator{match_type: :child}, html_node, _tree) do
+    Enum.reverse(html_node.children_nodes_ids)
   end
 
-  defp traverse_with(
-         %Selector.Combinator{match_type: :sibling, selector: s},
-         html_node,
-         tree,
-         acc
-       ) do
+  defp get_selector_nodes(%Selector.Combinator{match_type: :sibling}, html_node, tree) do
     case get_siblings(html_node, tree) do
-      [sibling_id | _] -> traverse_with(s, sibling_id, tree, acc)
-      _ -> acc
+      [sibling_id | _] -> sibling_id
+      _ -> nil
     end
   end
 
-  defp traverse_with(
-         %Selector.Combinator{match_type: :general_sibling, selector: s},
-         html_node,
-         tree,
-         acc
-       ) do
-    traverse_with(s, get_siblings(html_node, tree), tree, acc)
+  defp get_selector_nodes(%Selector.Combinator{match_type: :general_sibling}, html_node, tree) do
+    get_siblings(html_node, tree)
   end
 
-  defp traverse_with(
-         %Selector.Combinator{match_type: :descendant, selector: s},
-         html_node,
-         tree,
-         acc
-       ) do
-    traverse_with(s, get_descendant_ids(html_node.node_id, tree), tree, acc)
+  defp get_selector_nodes(%Selector.Combinator{match_type: :descendant}, html_node, tree) do
+    get_descendant_ids(html_node.node_id, tree)
   end
 
   defp get_node(id, tree) do

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -17,15 +17,15 @@ defmodule Floki.Finder do
 
   def find(html_tree, selector_as_string) when is_binary(selector_as_string) do
     selectors = get_selectors(selector_as_string)
-    find_selectors(html_tree, selectors)
+    find(html_tree, selectors)
+  end
+
+  def find(html_tree, selector = %Selector{}) do
+    find(html_tree, [selector])
   end
 
   def find(html_tree, selectors) when is_list(selectors) do
     find_selectors(html_tree, selectors)
-  end
-
-  def find(html_tree, selector = %Selector{}) do
-    find_selectors(html_tree, [selector])
   end
 
   @spec map(Floki.html_tree() | Floki.html_node(), function()) ::

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -25,28 +25,20 @@ defmodule Floki.Finder do
   end
 
   def find(html_tree, selectors) when is_list(selectors) do
-    find_selectors(html_tree, selectors)
-  end
-
-  defp find_selectors(html_tuple_or_list, selectors) do
-    tree = HTMLTree.build(html_tuple_or_list)
+    tree = HTMLTree.build(html_tree)
 
     results =
       tree.node_ids
       |> Enum.reverse()
       |> Enum.reduce([], fn node_id, acc ->
-        get_matches_for_selectors(tree, node_id, selectors, acc)
+        Enum.reduce(selectors, acc, fn selector, acc ->
+          traverse_with(selector, node_id, tree, acc)
+        end)
       end)
       |> Enum.reverse()
       |> Enum.uniq()
 
     {tree, results}
-  end
-
-  defp get_matches_for_selectors(tree, node_id, selectors, acc) do
-    Enum.reduce(selectors, acc, fn selector, acc ->
-      traverse_with(selector, node_id, tree, acc)
-    end)
   end
 
   # The stack serves as accumulator when there is another combinator to traverse.

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -16,7 +16,7 @@ defmodule Floki.Finder do
   def find(html_as_string, _) when is_binary(html_as_string), do: {%HTMLTree{}, []}
 
   def find(html_tree, selector_as_string) when is_binary(selector_as_string) do
-    selectors = get_selectors(selector_as_string)
+    selectors = Selector.Parser.parse(selector_as_string)
     find(html_tree, selectors)
   end
 
@@ -52,12 +52,6 @@ defmodule Floki.Finder do
       |> Enum.uniq()
 
     {tree, results}
-  end
-
-  defp get_selectors(selector_as_string) do
-    selector_as_string
-    |> Selector.Tokenizer.tokenize()
-    |> Selector.Parser.parse()
   end
 
   defp get_matches_for_selectors(tree, node_id, selectors, acc) do

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -43,7 +43,6 @@ defmodule Floki.Finder do
 
   # The stack serves as accumulator when there is another combinator to traverse.
   # So the scope of one combinator is the stack (or acc) or the parent one.
-  defp traverse_with(nil, html_node, _, acc), do: [html_node | acc]
   defp traverse_with(_, [], _, acc), do: acc
 
   defp traverse_with(selector, [node_id | rest], tree, acc) do
@@ -53,6 +52,16 @@ defmodule Floki.Finder do
       tree,
       traverse_with(selector, node_id, tree, acc)
     )
+  end
+
+  defp traverse_with(%Selector{combinator: nil} = selector, node_id, tree, acc) do
+    html_node = get_node(node_id, tree)
+
+    if Selector.match?(html_node, selector, tree) do
+      [html_node | acc]
+    else
+      acc
+    end
   end
 
   defp traverse_with(%Selector{combinator: combinator} = selector, node_id, tree, acc) do


### PR DESCRIPTION
Today Finder uses Enum.reduce and nested calls to traverse_with to do it's filtering.

This works fine when using HTMLTree, but this structure makes it harder to optimize some cases in which the HTMLTree isn't necessary (https://github.com/philss/floki/issues/515).

This PRs updates Finder to use a stack, similar to what we have on HTMLTree.build_tree. This makes it easier to implement the change for the ticket above, or other future changes to operations that don't need the HTMLTree.build step.

I also did some other clean ups in this module, I've split each change in a separated commit.

Performance is basically the same, but when profiling the timing is a lot better and more readable because of the removal of Enum.reduce

Before - selector `span a * i` 
```
%                                                           CNT           ACC           OWN        
[{ "<0.99.0>",                                           278908,    undefined,      442.743}].   %%

{  {'Elixir.Enum','-reduce/3-lists^foldl/2-0-',3},        29692,      402.120,       50.704}.      
{  {'Elixir.Floki.Finder',traverse_with,4},               18660,      309.861,       50.072}.      
{  {'Elixir.Floki.Selector','match?',3},                  12986,      160.655,       42.984}.      
{  {'Elixir.Floki.HTMLTree',build_tree,5},                15867,       39.761,       28.100}.      
{  {'Elixir.String',split,3},                              6522,       73.182,       26.562}.      
```

After
```
%                                                           CNT           ACC           OWN        
[{ "<0.99.0>",                                           231183,    undefined,      363.851}].   %%

{  {'Elixir.Floki.Finder',traverse_with,4},               38959,      322.261,       66.273}.      
{  {'Elixir.Floki.Selector','match?',3},                  12986,      158.041,       42.423}.      
{  {'Elixir.Floki.HTMLTree',build_tree,5},                15867,       40.198,       28.321}.      
{  {'Elixir.String',split,3},                              6522,       71.817,       26.114}.       
```
