### PR TITLE
Polymorphism on Finder.find

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -280,17 +280,13 @@ defmodule Floki do
     )
 
     with {:ok, document} <- Floki.parse_document(html) do
-      {tree, results} = Finder.find(document, selector)
-
-      Enum.map(results, fn html_node -> HTMLTree.to_tuple(tree, html_node) end)
+      Finder.find(document, selector)
     end
   end
 
   def find(html_tree_as_tuple, selector)
       when is_list(html_tree_as_tuple) or is_html_node(html_tree_as_tuple) do
-    {tree, results} = Finder.find(html_tree_as_tuple, selector)
-
-    Enum.map(results, fn html_node -> HTMLTree.to_tuple(tree, html_node) end)
+    Finder.find(html_tree_as_tuple, selector)
   end
 
   @doc """
@@ -385,7 +381,8 @@ defmodule Floki do
           ({String.t(), html_attributes()} -> {String.t(), html_attributes()} | :delete)
         ) :: html_tree()
   def find_and_update(html_tree, selector, fun) do
-    {tree, results} = Finder.find(html_tree, selector)
+    tree = HTMLTree.build(html_tree)
+    results = Finder.find(tree, selector)
 
     operations_with_nodes =
       Enum.map(results, fn


### PR DESCRIPTION
Today Finder.find expects a list of html_node tuples, and returns an HTMLTree and a list of resulting HTMLNode.

To allow the changes for #515, we need to return html_nodes only when we don't need to later use the HTMLTree. If receiving an HTMLTree, Finder.find will return a  list of HTMLNode, and if receiving a list of html_nodes the return will be a list of html_nodes. 

For now we'll keep building an HTMLTree for the search, but this allow a future change to avoid building the HTMLTree on simple selectors without having to change modules using Finder.

This is a breaking change for projects using Finder.find directly. 