### PR TITLE
Fix pretty raw_html with encoded text

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -213,10 +213,13 @@ defmodule Floki.RawHTML do
   defp leftpad(:noop), do: ""
   defp leftpad(%{pad: pad, depth: depth}), do: String.duplicate(pad, depth)
 
-  defp leftpad_content(:noop, string), do: string
+  defp leftpad_content(:noop, content), do: content
 
-  defp leftpad_content(padding, string) do
-    trimmed = String.trim(string)
+  defp leftpad_content(padding, content) do
+    trimmed =
+      content
+      |> IO.iodata_to_binary()
+      |> String.trim()
 
     if trimmed == "" do
       ""

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -484,7 +484,10 @@ defmodule FlokiTest do
         <div class="content">
           <span>
             <div>
-              "encoded content &'"
+              encoded content
+              &
+              '
+              "
 
       <span>
                 <small>
@@ -518,7 +521,10 @@ defmodule FlokiTest do
                <div class="content">
                  <span>
                    <div>
-                     &quot;encoded content &amp;&#39;&quot;
+                     encoded content
+                     &amp;
+                     &#39;
+                     &quot;
                      <span>
                        <small>
                          very deep content

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -484,6 +484,7 @@ defmodule FlokiTest do
         <div class="content">
           <span>
             <div>
+              "encoded content &'"
 
       <span>
                 <small>
@@ -517,6 +518,7 @@ defmodule FlokiTest do
                <div class="content">
                  <span>
                    <div>
+                     &quot;encoded content &amp;&#39;&quot;
                      <span>
                        <small>
                          very deep content


### PR DESCRIPTION
After https://github.com/philss/floki/pull/512, Entities.encode returns iodata instead of string when the content if the content got encoded. 
RawHTML.leftpad_content was expecting a string, which caused it to fail when trying to trim the value.