### PR TITLE
Optimize leftpad on raw_html

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -43,7 +43,7 @@ defmodule Floki.RawHTML do
 
     padding =
       case Keyword.fetch(options, :pretty) do
-        {:ok, true} -> %{pad: "  ", line_ending: "\n", depth: 0}
+        {:ok, true} -> %{pad: "", pad_increase: "  ", line_ending: "\n", depth: 0}
         _ -> :noop
       end
 
@@ -211,7 +211,7 @@ defmodule Floki.RawHTML do
     do: map_intersperse(Map.to_list(attrs), separator, mapper)
 
   defp leftpad(:noop), do: ""
-  defp leftpad(%{pad: pad, depth: depth}), do: String.duplicate(pad, depth)
+  defp leftpad(%{pad: pad}), do: pad
 
   defp leftpad_content(:noop, string), do: string
 
@@ -226,7 +226,11 @@ defmodule Floki.RawHTML do
   end
 
   defp pad_increase(:noop), do: :noop
-  defp pad_increase(padder = %{depth: depth}), do: %{padder | depth: depth + 1}
+
+  defp pad_increase(padder = %{depth: depth, pad_increase: pad_increase}) do
+    depth = depth + 1
+    %{padder | depth: depth, pad: String.duplicate(pad_increase, depth)}
+  end
 
   defp line_ending(:noop), do: ""
   defp line_ending(%{line_ending: line_ending}), do: line_ending

--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -178,10 +178,11 @@ defmodule Floki.RawHTML do
         _ -> encoder
       end
 
-    children_content = case children do
-      [] -> ""
-      _ -> build_raw_html(children, "", encoder, pad_increase(padding), self_closing_tags)
-    end
+    children_content =
+      case children do
+        [] -> ""
+        _ -> build_raw_html(children, "", encoder, pad_increase(padding), self_closing_tags)
+      end
 
     [
       tag_with_attrs(type, attrs, children, padding, encoder, self_closing_tags),

--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -178,10 +178,15 @@ defmodule Floki.RawHTML do
         _ -> encoder
       end
 
+    children_content = case children do
+      [] -> ""
+      _ -> build_raw_html(children, "", encoder, pad_increase(padding), self_closing_tags)
+    end
+
     [
       tag_with_attrs(type, attrs, children, padding, encoder, self_closing_tags),
       line_ending(padding),
-      build_raw_html(children, "", encoder, pad_increase(padding), self_closing_tags),
+      children_content,
       close_end_tag(type, children, padding, self_closing_tags)
     ]
   end


### PR DESCRIPTION
Today leftpad calls String.duplicate, which ends up being significantly costly when generating a pretty raw html, since this is used on each line being generated.

This PR moves the string creation to `pad_increase`, instead of doing it on every call to `leftpad`.

```
##### With input big #####
Name                 ips        average  deviation         median         99th %
bench (pr)         35.87       27.88 ms    ±11.34%       27.06 ms       41.01 ms
bench              33.05       30.26 ms     ±6.39%       30.00 ms       34.48 ms

Comparison: 
bench (pr)         35.87
bench              33.05 - 1.09x slower +2.38 ms

Memory usage statistics:

Name          Memory usage
bench (pr)        12.68 MB
bench             13.83 MB - 1.09x memory usage +1.15 MB

**All measurements for memory usage were the same**

##### With input medium #####
Name                 ips        average  deviation         median         99th %
bench (pr)        133.80        7.47 ms    ±17.97%        7.08 ms       10.64 ms
bench             117.21        8.53 ms    ±16.18%        8.29 ms       11.99 ms

Comparison: 
bench (pr)        133.80
bench             117.21 - 1.14x slower +1.06 ms

Memory usage statistics:

Name          Memory usage
bench (pr)         4.14 MB
bench              4.49 MB - 1.09x memory usage +0.36 MB

**All measurements for memory usage were the same**

##### With input small #####
Name                 ips        average  deviation         median         99th %
bench (pr)        749.69        1.33 ms    ±25.91%        1.30 ms        2.17 ms
bench             648.79        1.54 ms    ±23.00%        1.46 ms        2.48 ms

Comparison: 
bench (pr)        749.69
bench             648.79 - 1.16x slower +0.21 ms

Memory usage statistics:

Name          Memory usage
bench (pr)       891.88 KB
bench            960.57 KB - 1.08x memory usage +68.69 KB

**All measurements for memory usage were the same**
```
```
read_file = fn name ->
  __ENV__.file
  |> Path.dirname()
  |> Path.join(name)
  |> File.read!()
  |> Floki.parse_document!()
end

inputs = %{
  "big" => read_file.("big.html"),
  "medium" => read_file.("medium.html"),
  "small" => read_file.("small.html")
}

Benchee.run(
  %{
    "bench" => fn doc -> Floki.raw_html(doc, pretty: true) end
  },
  time: 10,
  inputs: inputs,
  memory_time: 2
)
```