### PR TITLE
Optimize Floki.children

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -609,19 +609,21 @@ defmodule Floki do
   """
 
   @spec children(html_node(), Keyword.t()) :: html_tree() | nil
+  def children(html_node, opts \\ [include_text: true])
 
-  def children(html_node, opts \\ [include_text: true]) do
-    case html_node do
-      {_, _, subtree} ->
-        filter_children(subtree, opts[:include_text])
-
-      _ ->
-        nil
-    end
+  def children({_, _, subtree}, include_text: false) do
+    Enum.filter(subtree, &is_tuple/1)
   end
 
-  defp filter_children(children, false), do: Enum.filter(children, &is_tuple(&1))
-  defp filter_children(children, _), do: children
+  def children({_, _, subtree}, include_text: _) do
+    subtree
+  end
+
+  def children({_, _, _} = html_node, opts) do
+    children(html_node, include_text: opts[:include_text])
+  end
+
+  def children(_html_node, _opts), do: nil
 
   @doc """
   Returns a list with attribute values for a given selector.

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1564,10 +1564,17 @@ defmodule FlokiTest do
   # Floki.children/2
 
   test "returns the children elements of an element including the text" do
-    assert Floki.children({"div", [], ["a parent", {"span", [], ["a child"]}]}) == [
-             "a parent",
-             {"span", [], ["a child"]}
-           ]
+    html_node = {"div", [], ["a parent", {"span", [], ["a child"]}]}
+
+    expected = [
+      "a parent",
+      {"span", [], ["a child"]}
+    ]
+
+    assert Floki.children(html_node) == expected
+    assert Floki.children(html_node, include_text: true) == expected
+    assert Floki.children(html_node, include_text: true, unknown_option: true) == expected
+    assert Floki.children(html_node, unknown_option: true) == expected
   end
 
   test "returns the children elements of an element without the text" do
@@ -1576,14 +1583,19 @@ defmodule FlokiTest do
 
     [elements | _] = Floki.find(html, "body > div")
 
-    assert [
-             {"span", [], ["child 1"]},
-             {"span", [], ["child 2"]}
-           ] = Floki.children(elements, include_text: false)
+    expected = [
+      {"span", [], ["child 1"]},
+      {"span", [], ["child 2"]}
+    ]
+
+    assert Floki.children(elements, include_text: false) == expected
+    assert Floki.children(elements, include_text: false, unknown_option: true) == expected
   end
 
   test "returns nil if the given html is not a valid tuple" do
     assert Floki.children([]) == nil
+    assert Floki.children([], include_text: true) == nil
+    assert Floki.children([], include_text: false) == nil
   end
 
   # Floki.attribute/3


### PR DESCRIPTION
Floki.children is called a lot by Phoenix LiveView when doing tests. On the project I'm working on, this functions gets called more than 8 million times when running all of our tests. 

This PR adds some pattern matching to this function to avoid using `Access.get` if possible.

```
Name                      ips        average  deviation         median         99th %
children (pr)         11.50 K       86.95 μs   ±239.29%       53.26 μs     1559.21 μs
children (main)        7.19 K      139.07 μs   ±145.06%      104.25 μs     1507.63 μs

Comparison: 
children (pr)         11.50 K
children (main)        7.19 K - 1.60x slower +52.12 μs
``` 
```

read_file = fn name ->
  __ENV__.file
  |> Path.dirname()
  |> Path.join(name)
  |> File.read!()
  |> Floki.parse_document!()
end

doc = read_file.("small.html")
html_nodes = Floki.find(doc, "*")

Benchee.run(
  %{
    "children" => fn ->
      for html_node <- html_nodes do
        Floki.children(html_node)
        Floki.children(html_node, include_text: false)
        Floki.children(html_node, include_text: true)
      end
    end
  },
  time: 10,
  save: [path: "benchs/results/finder-#{tag}.benchee", tag: tag],
  memory_time: 2
)
```