### PR TITLE
Always return find elements in the correct order

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -47,7 +47,7 @@ defmodule Floki.Finder do
     stack = Enum.map(selectors, fn s -> {s, node_ids} end)
 
     traverse_html_tree(stack, tree, [])
-    |> Enum.reverse()
+    |> Enum.sort_by(& &1.node_id)
     |> Enum.uniq()
   end
 

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -917,15 +917,24 @@ defmodule FlokiTest do
   # Floki.find/2 - Selector with descendant combinator
 
   test "get elements descending the parent" do
+    doc =
+      document!(
+        html_body("""
+        <div id="first-div">
+          <div id="second-div">
+            <span id="first-span"></span>
+          </div>
+          <span id="second-span"></span>
+        </div>
+        """)
+      )
+
     expected = [
-      {
-        "img",
-        [{"src", "http://twitter.com/logo.png"}, {"class", "js-twitter-logo"}],
-        []
-      }
+      {"span", [{"id", "first-span"}], []},
+      {"span", [{"id", "second-span"}], []}
     ]
 
-    assert_find(document!(@html_with_img), "a img", expected)
+    assert_find(doc, "div span", expected)
   end
 
   # Floki.find/2 - Selector with child combinator
@@ -1051,6 +1060,7 @@ defmodule FlokiTest do
     ]
 
     assert_find(document!(@html_with_img), ".js-twitter-logo, #logo", expected)
+    assert_find(document!(@html_with_img), "#logo, .js-twitter-logo", expected)
   end
 
   test "get one element when search for multiple and just one exist" do


### PR DESCRIPTION
Instead of expecting `traverse_html_tree` to return elements in the correct order, we'll now use the `node_id` to sort find results.
Fixes #539 