### PR TITLE
Use adjacent_sibling instead of sibling

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -191,7 +191,7 @@ defmodule Floki.Finder do
     Enum.reverse(html_node.children_nodes_ids)
   end
 
-  defp get_selector_nodes(%Selector.Combinator{match_type: :sibling}, html_node, tree) do
+  defp get_selector_nodes(%Selector.Combinator{match_type: :adjacent_sibling}, html_node, tree) do
     case get_siblings(html_node, tree) do
       [sibling_id | _] -> [sibling_id]
       _ -> []

--- a/lib/floki/selector/parser.ex
+++ b/lib/floki/selector/parser.ex
@@ -131,7 +131,7 @@ defmodule Floki.Selector.Parser do
   end
 
   defp do_parse([{:plus, _} | t], selector) do
-    {remaining_tokens, combinator} = consume_combinator(t, :sibling)
+    {remaining_tokens, combinator} = consume_combinator(t, :adjacent_sibling)
 
     {%{selector | combinator: combinator}, remaining_tokens}
   end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1009,9 +1009,9 @@ defmodule FlokiTest do
     assert_find(html, "div > p > span > img + img", expected)
   end
 
-  # Floki.find/2 - Sibling combinator
+  # Floki.find/2 - Adjacent sibling combinator
 
-  test "find sibling element" do
+  test "find adjacent sibling element" do
     html = document!(html_body(~s(
               <a href="t"><img src="/l.png" class="js-l"></a>
               <!-- comment -->


### PR DESCRIPTION
`+` combinator was being parsed as `:sibling`, while `Floki.Selector.Combinator` expected `:adjacent_sibling` to be used for this combinator. 
This PR changes all all usages of  `:sibling` to `:adjacent_sibling`