### PR TITLE
add Floki.find_by_id/2

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -290,6 +290,32 @@ defmodule Floki do
   end
 
   @doc """
+  Finds the first element in an HTML tree by id.
+
+  Returns `nil` if no element is found.
+
+  This is useful when there are IDs that contain special characters that
+  are invalid when passed as is as a CSS selector.
+  It is similar to the `getElementById` method in the browser.
+
+  ## Examples
+
+      iex> {:ok, html} = Floki.parse_fragment(~s[<p><span class="hint" id="id?foo_special:chars">hello</span></p>])
+      iex> Floki.get_by_id(html, "id?foo_special:chars")
+      {"span", [{"class", "hint"}, {"id", "id?foo_special:chars"}], ["hello"]}
+      iex> Floki.get_by_id(html, "does-not-exist")
+      nil
+
+  """
+  @spec get_by_id(html_tree() | html_node(), String.t()) :: html_tree
+  def get_by_id(html_tree_as_tuple, id)
+      when is_list(html_tree_as_tuple) or is_html_node(html_tree_as_tuple) do
+    html_tree_as_tuple
+    |> Finder.find(%Floki.Selector{id: id})
+    |> List.first()
+  end
+
+  @doc """
   Changes the attribute values of the elements matched by `selector`
   with the function `mutation` and returns the whole element tree.
 

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1594,6 +1594,22 @@ defmodule FlokiTest do
              Floki.Finder.find(html_tree, [selector_struct_1, selector_struct_2])
   end
 
+  # Floki.get_by_id/2
+
+  test "get_by_id finds element with special characters" do
+    html =
+      document!(
+        html_body(~s"""
+        <div id="my-id?with_special!char:acters">Hello</div>
+        """)
+      )
+
+    assert {"div", [{"id", "my-id?with_special!char:acters"}], ["Hello"]} =
+             Floki.get_by_id(html, "my-id?with_special!char:acters")
+
+    refute Floki.get_by_id(html, "doesn't exist")
+  end
+
   # Floki.children/2
 
   test "returns the children elements of an element including the text" do


### PR DESCRIPTION
Related to the problem and discussion in https://github.com/phoenixframework/phoenix_live_view/issues/3144.

In LiveViewTest we need to find elements by their id. Currently, we use `Floki.find(html, "##{id}")`, but this breaks as soon as there are special characters in the id. We could use `Floki.find(html, %Floki.Selector{id: id})`, but the `Floki.Selector` struct is not documented and therefore I'm not sure if it's something to rely on.

As `document.getElementById` is also a frequently used API in the browser, adding a `find_by_id` or similar function to Floki could be quite useful.

This PR adds a simple find_by_id function that internally uses the `%Floki.Selector{id: id}` struct.
As using find with a string is deprecated, I did not add this functionality to find_by_id.