### PR TITLE
Support escaped '?' in id selector, e.g. '#active\?'

### DIFF
--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -1,7 +1,7 @@
 Definitions.
 
-ESCAPED = \\[:.]
-IDENTIFIER = [-A-Za-z0-9_]+(({ESCAPED})?[-A-Za-z0-9_]+)*
+ESCAPED = \\[:.?]
+IDENTIFIER = [-A-Za-z0-9_]+(({ESCAPED})?[-A-Za-z0-9_]+)*({ESCAPED})?
 QUOTED = (\"[^"]*\"|\'[^']*\')
 PARENTESIS = \([^)]*\)
 INT = [0-9]+
@@ -56,4 +56,4 @@ unescape_inside_class_name(Chars) ->
   lists:flatten(string:replace(Chars, "\\:", ":", all)).
 
 unescape_inside_id_name(Chars) ->
-  lists:flatten(string:replace(Chars, "\\.", ".", all)).
+  lists:flatten(string:replace(string:replace(Chars, "\\.", ".", all), "\\?", "?", all)).

--- a/test/floki/selector/parser_test.exs
+++ b/test/floki/selector/parser_test.exs
@@ -31,6 +31,14 @@ defmodule Floki.Selector.ParserTest do
            ]
   end
 
+  test "escaped question mark in id" do
+    tokens = tokenize("input#active\\?")
+
+    assert Parser.parse(tokens) == [
+             %Selector{type: "input", id: "active?"}
+           ]
+  end
+
   test "reorders classes in selector to improve matching performance" do
     tokens = tokenize(".small.longer.even-longer")
 


### PR DESCRIPTION
Use case: ID selector for a checkbox input.