### PR TITLE
raw_html treats the content of title tags as plain text

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -178,6 +178,7 @@ defmodule Floki.RawHTML do
       case type do
         "script" -> @no_encoder
         "style" -> @no_encoder
+        "title" -> @no_encoder
         _ -> encoder
       end
 

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -564,7 +564,7 @@ defmodule FlokiTest do
   end
 
   test "raw_html treats the contents of title tags as plain text" do
-    html_string = ~s(<title> <b> bold </b> text </title>)
+    html_string = ~s(<html><head><title> <b> bold </b> text </title></head><body></body></html>)
     parsed = Floki.parse_document!(html_string)
     assert ^html_string = Floki.raw_html(parsed)
   end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -563,6 +563,12 @@ defmodule FlokiTest do
     assert recombined
   end
 
+  test "raw_html treats the contents of title tags as plain text" do
+    html_string = ~s(<title> <b> bold </b> text </title>)
+    parsed = Floki.parse_document!(html_string)
+    assert ^html_string = Floki.raw_html(parsed)
+  end
+
   # Floki.find/2 - Classes
 
   test "find elements with a given class" do


### PR DESCRIPTION
`parse_document` correctly treats the content of title tags as plain text. But `raw_html` does not. This PR fixes that.