### PR TITLE
Find without html tree for some pseudo classes

### DIFF
--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -118,6 +118,14 @@ defmodule Floki.Selector.PseudoClass do
     attribute_is_present?(html_node.attributes, "selected")
   end
 
+  def match_checked?({"input", attributes, _children}) do
+    attribute_is_present?(attributes, "checked")
+  end
+
+  def match_checked?({"option", attributes, _children}) do
+    attribute_is_present?(attributes, "selected")
+  end
+
   def match_checked?(_), do: false
 
   defp attribute_is_present?(attributes, attribute_name) when is_list(attributes) do
@@ -132,6 +140,10 @@ defmodule Floki.Selector.PseudoClass do
 
   def match_disabled?(%{type: type} = html_node) when type in @disableable_html_nodes do
     attribute_is_present?(html_node.attributes, "disabled")
+  end
+
+  def match_disabled?({type, attributes, _children}) when type in @disableable_html_nodes do
+    attribute_is_present?(attributes, "disabled")
   end
 
   def match_disabled?(_html_node), do: false


### PR DESCRIPTION
This PR adds support for traversal without building HTMLTree for the pseudo-classes that don't require tree information - `:checked`, `:disabled`, and `:not` not using any of the other pseudo-classes. 

Final PR for https://github.com/philss/floki/issues/515

```
##### With input big #####
Name                                       ips        average  deviation         median         99th %
checked (pr)                            593.06        1.69 ms     ±8.05%        1.66 ms        2.22 ms
disabled (pr)                           593.05        1.69 ms     ±7.67%        1.66 ms        2.19 ms
not checked (pr)                        588.96        1.70 ms    ±13.37%        1.66 ms        2.58 ms
checked (v0.36.2-4-gc3417a5)             35.65       28.05 ms    ±58.88%       21.24 ms       83.09 ms
disabled (v0.36.2-4-gc3417a5)            34.80       28.74 ms    ±54.31%       22.21 ms       72.75 ms
not checked (v0.36.2-4-gc3417a5)         30.42       32.87 ms    ±53.87%       25.51 ms       87.42 ms

Comparison: 
checked (pr)                            593.06
disabled (pr)                           593.05 - 1.00x slower +0.00004 ms
not checked (pr)                        588.96 - 1.01x slower +0.0118 ms
checked (v0.36.2-4-gc3417a5)             35.65 - 16.63x slower +26.36 ms
disabled (v0.36.2-4-gc3417a5)            34.80 - 17.04x slower +27.05 ms
not checked (v0.36.2-4-gc3417a5)         30.42 - 19.49x slower +31.18 ms

Memory usage statistics:

Name                                Memory usage
checked (pr)                             1.87 MB
disabled (pr)                            1.87 MB - 1.00x memory usage -0.00024 MB
not checked (pr)                         1.88 MB - 1.00x memory usage +0.00188 MB
checked (v0.36.2-4-gc3417a5)             9.46 MB - 5.04x memory usage +7.58 MB
disabled (v0.36.2-4-gc3417a5)            9.45 MB - 5.04x memory usage +7.58 MB
not checked (v0.36.2-4-gc3417a5)         9.46 MB - 5.05x memory usage +7.58 MB

**All measurements for memory usage were the same**

##### With input medium #####
Name                                       ips        average  deviation         median         99th %
not checked (pr)                        1.82 K        0.55 ms     ±6.03%        0.53 ms        0.68 ms
checked (pr)                            1.82 K        0.55 ms     ±7.04%        0.54 ms        0.70 ms
disabled (pr)                           1.82 K        0.55 ms     ±7.29%        0.53 ms        0.71 ms
checked (v0.36.2-4-gc3417a5)            0.35 K        2.82 ms     ±8.00%        2.77 ms        4.08 ms
disabled (v0.36.2-4-gc3417a5)           0.35 K        2.84 ms     ±7.87%        2.78 ms        4.01 ms
not checked (v0.36.2-4-gc3417a5)        0.35 K        2.90 ms     ±8.97%        2.84 ms        4.30 ms

Comparison: 
not checked (pr)                        1.82 K
checked (pr)                            1.82 K - 1.00x slower +0.00163 ms
disabled (pr)                           1.82 K - 1.00x slower +0.00184 ms
checked (v0.36.2-4-gc3417a5)            0.35 K - 5.14x slower +2.27 ms
disabled (v0.36.2-4-gc3417a5)           0.35 K - 5.17x slower +2.29 ms
not checked (v0.36.2-4-gc3417a5)        0.35 K - 5.29x slower +2.35 ms

Memory usage statistics:

Name                                Memory usage
not checked (pr)                         0.61 MB
checked (pr)                             0.61 MB - 1.00x memory usage -0.00173 MB
disabled (pr)                            0.61 MB - 1.00x memory usage -0.00204 MB
checked (v0.36.2-4-gc3417a5)             2.74 MB - 4.49x memory usage +2.13 MB
disabled (v0.36.2-4-gc3417a5)            2.74 MB - 4.49x memory usage +2.13 MB
not checked (v0.36.2-4-gc3417a5)         2.74 MB - 4.50x memory usage +2.13 MB

**All measurements for memory usage were the same**

##### With input small #####
Name                                       ips        average  deviation         median         99th %
not checked (pr)                        8.69 K      115.08 μs    ±12.09%      112.32 μs      171.40 μs
checked (pr)                            8.68 K      115.25 μs    ±16.25%      110.24 μs      185.13 μs
disabled (pr)                           8.52 K      117.41 μs    ±19.30%      111.78 μs      239.50 μs
disabled (v0.36.2-4-gc3417a5)           1.78 K      561.55 μs    ±18.67%      584.53 μs      759.41 μs
checked (v0.36.2-4-gc3417a5)            1.78 K      562.87 μs    ±19.39%      591.40 μs      819.01 μs
not checked (v0.36.2-4-gc3417a5)        1.70 K      586.67 μs    ±20.81%      610.79 μs      992.99 μs

Comparison: 
not checked (pr)                        8.69 K
checked (pr)                            8.68 K - 1.00x slower +0.175 μs
disabled (pr)                           8.52 K - 1.02x slower +2.33 μs
disabled (v0.36.2-4-gc3417a5)           1.78 K - 4.88x slower +446.47 μs
checked (v0.36.2-4-gc3417a5)            1.78 K - 4.89x slower +447.79 μs
not checked (v0.36.2-4-gc3417a5)        1.70 K - 5.10x slower +471.59 μs

Memory usage statistics:

Name                                Memory usage
not checked (pr)                       130.06 KB
checked (pr)                           128.21 KB - 0.99x memory usage -1.85156 KB
disabled (pr)                          127.97 KB - 0.98x memory usage -2.09375 KB
disabled (v0.36.2-4-gc3417a5)          619.08 KB - 4.76x memory usage +489.02 KB
checked (v0.36.2-4-gc3417a5)           619.32 KB - 4.76x memory usage +489.26 KB
not checked (v0.36.2-4-gc3417a5)       621.93 KB - 4.78x memory usage +491.87 KB

```