### PR TITLE
Stop get_by_id traversal on first match

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -308,12 +308,7 @@ defmodule Floki do
 
   """
   @spec get_by_id(html_tree() | html_node(), String.t()) :: html_node() | nil
-  def get_by_id(html_tree_as_tuple, id)
-      when is_list(html_tree_as_tuple) or is_html_node(html_tree_as_tuple) do
-    html_tree_as_tuple
-    |> Finder.find(%Floki.Selector{id: id})
-    |> List.first()
-  end
+  defdelegate get_by_id(html_tree_as_tuple, id), to: Finder, as: :find_by_id
 
   @doc """
   Changes the attribute values of the elements matched by `selector`

--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -9,6 +9,28 @@ defmodule Floki.Finder do
   alias Selector.PseudoClass
   import Floki, only: [is_html_node: 1]
 
+  @spec find_by_id(Floki.html_tree() | Floki.html_node(), String.t()) :: Floki.html_node() | nil
+  def find_by_id(html_tree_as_tuple, id) do
+    html_tree_as_tuple = List.wrap(html_tree_as_tuple)
+    traverse_find_by_id(html_tree_as_tuple, id)
+  end
+
+  defp traverse_find_by_id([{_type, _attributes, children} = html_tuple | rest], id) do
+    if Selector.id_match?(html_tuple, id) do
+      html_tuple
+    else
+      traverse_find_by_id(children, id) || traverse_find_by_id(rest, id)
+    end
+  end
+
+  defp traverse_find_by_id([_ | rest], id) do
+    traverse_find_by_id(rest, id)
+  end
+
+  defp traverse_find_by_id([], _id) do
+    nil
+  end
+
   # Find elements inside a HTML tree.
   # Second argument can be either a selector string, a selector struct or a list of selector structs.
 

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -99,8 +99,8 @@ defmodule Floki.Selector do
 
   defp can_match_combinator?(_node, _combinator), do: true
 
-  defp id_match?(_node, nil), do: true
-  defp id_match?(node, id), do: attribute_value(node, "id") == id
+  def id_match?(_node, nil), do: true
+  def id_match?(node, id), do: attribute_value(node, "id") == id
 
   defp namespace_match?(_node, namespace) when is_wildcard(namespace), do: true
 


### PR DESCRIPTION
Today get_by_id just calls Finder.find and gets the first item in the list.
This PR refactors this method to avoid the unnecessary checks on `match?` and check the id value directly, and to stop the traversal on the first matching element.

```
Benchee.run(
  %{
    "get_by_id - beginning document" => fn doc -> Floki.get_by_id(doc, "mw-page-base") end,
    "get_by_id - end document" => fn doc -> Floki.get_by_id(doc, "footer-poweredbyico") end
  },
  time: 10,
  inputs: inputs,
  save: [path: "benchs/results/finder-#{tag}.benchee", tag: tag],
  memory_time: 2
)
```
```
##### With input big #####
Name                                                          ips        average  deviation         median         99th %
get_by_id - beginning document (PR)                      691.49 K     0.00145 ms  ±2360.83%     0.00124 ms     0.00233 ms
get_by_id - end document (PR)                              1.36 K        0.74 ms    ±11.08%        0.70 ms        1.09 ms
get_by_id - beginning document (v0.36.2-6-gb04be56)        0.75 K        1.33 ms     ±9.20%        1.29 ms        1.88 ms
get_by_id - end document (v0.36.2-6-gb04be56)              0.75 K        1.34 ms     ±9.00%        1.30 ms        1.89 ms

Comparison: 
get_by_id - beginning document (PR)                      691.49 K
get_by_id - end document (PR)                              1.36 K - 509.97x slower +0.74 ms
get_by_id - beginning document (v0.36.2-6-gb04be56)        0.75 K - 922.09x slower +1.33 ms
get_by_id - end document (v0.36.2-6-gb04be56)              0.75 K - 925.15x slower +1.34 ms

Memory usage statistics:

Name                                                   Memory usage
get_by_id - beginning document (PR)                             0 B
get_by_id - end document (PR)                                   0 B - 1.00x memory usage +0 B
get_by_id - beginning document (v0.36.2-6-gb04be56)           120 B - ∞ x memory usage +120 B
get_by_id - end document (v0.36.2-6-gb04be56)                 120 B - ∞ x memory usage +120 B

**All measurements for memory usage were the same**

##### With input medium #####
Name                                                          ips        average  deviation         median         99th %
get_by_id - beginning document (PR)                      740.60 K        1.35 μs  ±2586.25%        1.17 μs        1.79 μs
get_by_id - end document (PR)                              3.78 K      264.49 μs    ±12.71%      253.67 μs      432.10 μs
get_by_id - beginning document (v0.36.2-6-gb04be56)        2.16 K      462.08 μs    ±12.16%      442.41 μs      711.64 μs
get_by_id - end document (v0.36.2-6-gb04be56)              2.16 K      462.52 μs    ±12.39%      446.88 μs      727.15 μs

Comparison: 
get_by_id - beginning document (PR)                      740.60 K
get_by_id - end document (PR)                              3.78 K - 195.88x slower +263.14 μs
get_by_id - beginning document (v0.36.2-6-gb04be56)        2.16 K - 342.22x slower +460.73 μs
get_by_id - end document (v0.36.2-6-gb04be56)              2.16 K - 342.54x slower +461.17 μs

Memory usage statistics:

Name                                                   Memory usage
get_by_id - beginning document (PR)                             0 B
get_by_id - end document (PR)                                   0 B - 1.00x memory usage +0 B
get_by_id - beginning document (v0.36.2-6-gb04be56)           120 B - ∞ x memory usage +120 B
get_by_id - end document (v0.36.2-6-gb04be56)                 120 B - ∞ x memory usage +120 B

**All measurements for memory usage were the same**

##### With input small #####
Name                                                          ips        average  deviation         median         99th %
get_by_id - beginning document (PR)                      690.85 K        1.45 μs  ±1595.44%        1.29 μs        1.73 μs
get_by_id - end document (PR)                             17.30 K       57.80 μs    ±20.12%       54.98 μs      110.33 μs
get_by_id - end document (v0.36.2-6-gb04be56)              9.88 K      101.18 μs    ±20.39%       93.89 μs      190.50 μs
get_by_id - beginning document (v0.36.2-6-gb04be56)        9.88 K      101.20 μs    ±19.41%       93.79 μs      180.39 μs

Comparison: 
get_by_id - beginning document (PR)                      690.85 K
get_by_id - end document (PR)                             17.30 K - 39.93x slower +56.35 μs
get_by_id - end document (v0.36.2-6-gb04be56)              9.88 K - 69.90x slower +99.73 μs
get_by_id - beginning document (v0.36.2-6-gb04be56)        9.88 K - 69.92x slower +99.76 μs

Memory usage statistics:

Name                                                   Memory usage
get_by_id - beginning document (PR)                             0 B
get_by_id - end document (PR)                                   0 B - 1.00x memory usage +0 B
get_by_id - end document (v0.36.2-6-gb04be56)                 120 B - ∞ x memory usage +120 B
get_by_id - beginning document (v0.36.2-6-gb04be56)           120 B - ∞ x memory usage +120 B
```

