### PR TITLE
Optimize raw html padding for small depths

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -236,6 +236,12 @@ defmodule Floki.RawHTML do
 
   defp pad_increase(@noop), do: @noop
 
+  for depth <- 0..100 do
+    @current_pad String.duplicate(" ", depth * @pad_increase)
+    @next_pad String.duplicate(" ", depth * @pad_increase + @pad_increase)
+    defp pad_increase(@current_pad), do: @next_pad
+  end
+
   defp pad_increase(pad) do
     String.duplicate(" ", byte_size(pad) + @pad_increase)
   end


### PR DESCRIPTION
Today on every `pad_increase` we're computing the new pad value using `String.duplicate`. This PR precomputes the pad increase string for values under 100 depth (arbitrary value), providing a small performance and memory improvement.

Changes:
- Move line ending from `padding` map to a separated variable
- Remove `line_ending/1` function and use the `line_ending` value directly
- Replace `padding` map variable with `pad` string value
- Remove `leftpad/1` function and use the `pad` value directly
- Precompute `pad_increase` for depths under 100


```
##### With input big #####
Name                   ips        average  deviation         median         99th %
bench (PR)           57.32       17.45 ms    ±12.32%       17.01 ms       20.79 ms
bench (main)         48.80       20.49 ms     ±6.44%       20.37 ms       26.05 ms

Comparison:
bench (PR)           57.32
bench (main)         48.80 - 1.17x slower +3.05 ms

Memory usage statistics:

Name            Memory usage
bench (PR)          11.51 MB
bench (main)        12.12 MB - 1.05x memory usage +0.61 MB

**All measurements for memory usage were the same**

##### With input medium #####
Name                   ips        average  deviation         median         99th %
bench (pr)          227.80        4.39 ms    ±31.57%        4.78 ms        6.24 ms
bench (main)        221.93        4.51 ms     ±9.86%        4.39 ms        6.20 ms

Comparison: 
bench (pr)          227.80
bench (main)        221.93 - 1.03x slower +0.116 ms

Memory usage statistics:

Name            Memory usage
bench (PR)           3.45 MB
bench (main)         3.77 MB - 1.09x memory usage +0.32 MB

**All measurements for memory usage were the same**

##### With input small #####
Name                   ips        average  deviation         median         99th %
bench (PR)          1.31 K        0.76 ms    ±24.67%        0.77 ms        1.19 ms
bench (main)        0.98 K        1.02 ms    ±18.62%        1.04 ms        1.47 ms

Comparison:
bench (PR)          1.31 K
bench (main)        0.98 K - 1.34x slower +0.26 ms

Memory usage statistics:

Name            Memory usage
bench (PR)         677.02 KB
bench (main)       774.63 KB - 1.14x memory usage +97.61 KB
```