### PR TITLE
Fix raw_html/2 typespec

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -247,7 +247,7 @@ defmodule Floki do
       \"\"\"
   """
 
-  @spec raw_html(html_tree | binary, keyword) :: binary
+  @spec raw_html(html_tree() | html_node() | binary(), keyword()) :: binary()
 
   defdelegate raw_html(html_tree, options \\ []), to: Floki.RawHTML
 


### PR DESCRIPTION
The function uses `List.wrap` internally, which means it accepts any `html_node`

Inadvertently, I created this bug 6 years ago!

![Screenshot 2024-10-01 at 3 10 37 PM](https://github.com/user-attachments/assets/f6495f12-76f3-4e73-b4c1-03c76bfe773c)
