### PR TITLE
Fix bug propagating identity encoder in `raw_html/2`

### DIFF
--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -133,7 +133,7 @@ defmodule Floki.RawHTML do
          self_closing_tags,
          line_ending
        ) do
-    encoder =
+    curr_encoder =
       case type do
         "script" -> @no_encoder
         "style" -> @no_encoder
@@ -142,7 +142,7 @@ defmodule Floki.RawHTML do
       end
 
     open_tag_content = [
-      tag_with_attrs(type, attrs, children, pad, encoder, self_closing_tags),
+      tag_with_attrs(type, attrs, children, pad, curr_encoder, self_closing_tags),
       line_ending
     ]
 
@@ -159,7 +159,8 @@ defmodule Floki.RawHTML do
           build_raw_html(
             children,
             acc,
-            encoder,
+            # Need to make sure to pass the encoder for the current node
+            curr_encoder,
             pad_increase(pad),
             self_closing_tags,
             line_ending
@@ -168,6 +169,7 @@ defmodule Floki.RawHTML do
 
     close_tag_content = close_end_tag(type, children, pad, self_closing_tags, line_ending)
     acc = [close_tag_content | acc]
+    # Return the original encoder here, we don't want to propagate that
     build_raw_html(tail, acc, encoder, pad, self_closing_tags, line_ending)
   end
 

--- a/lib/floki/raw_html.ex
+++ b/lib/floki/raw_html.ex
@@ -133,16 +133,8 @@ defmodule Floki.RawHTML do
          self_closing_tags,
          line_ending
        ) do
-    curr_encoder =
-      case type do
-        "script" -> @no_encoder
-        "style" -> @no_encoder
-        "title" -> @no_encoder
-        _ -> encoder
-      end
-
     open_tag_content = [
-      tag_with_attrs(type, attrs, children, pad, curr_encoder, self_closing_tags),
+      tag_with_attrs(type, attrs, children, pad, encoder, self_closing_tags),
       line_ending
     ]
 
@@ -155,6 +147,14 @@ defmodule Floki.RawHTML do
 
         _ ->
           children = List.wrap(children)
+
+          curr_encoder =
+            case type do
+              "script" -> @no_encoder
+              "style" -> @no_encoder
+              "title" -> @no_encoder
+              _ -> encoder
+            end
 
           build_raw_html(
             children,

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -449,25 +449,12 @@ defmodule FlokiTest do
       <head>
       </head>
       <body>
-        <div class="canvas">
-          <div class="row-container">
-            <div class="row" style="display: flex;flex-wrap: wrap;width: 100%;">
-              <div class="zone-container" style="flex: 1;">
-                <div class="zone">
-                  <div class="zone-content">
-                    <div class="button-wrapper appcues-actions-right" style="width:100%;text-align:right;font-size:14px;margin-top:25px;margin-bottom:0px;">
-                      <style>
-                        .button-wrapper>[data-step=prev]::before {content: none} .button-wrapper>.appcues-button[data-step=next]::after {content: none}
-                      </style>
-                      <a class="appcues-button-success appcues-button" data-field-id="some_id" id="button-some_id" style="text-align:center;border:undefinedpx solid undefined;padding-top:8px;padding-right:18px;padding-bottom:8px;padding-left:18px;" data-attrs-event="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}" data-step="next" role="button" tabindex="0">
-                        Next
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div>
+          <style>
+          </style>
+          <a data-attrs-event="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}">
+            Next
+          </a>
         </div>
       </body>
     </html>
@@ -476,25 +463,12 @@ defmodule FlokiTest do
     tree =
       document!(
         html_body(~S"""
-        <div class="canvas">
-          <div class="row-container">
-            <div class="row" style="display: flex;flex-wrap: wrap;width: 100%;">
-              <div class="zone-container" style="flex: 1;">
-                <div class="zone">
-                  <div class="zone-content">
-                    <div class="button-wrapper appcues-actions-right" style="width:100%;text-align:right;font-size:14px;margin-top:25px;margin-bottom:0px;">
-                      <style>
-                        .button-wrapper>[data-step=prev]::before {content: none} .button-wrapper>.appcues-button[data-step=next]::after {content: none}
-                      </style>
-                      <a class="appcues-button-success appcues-button" data-field-id="some_id" id="button-some_id" style="text-align:center;border:undefinedpx solid undefined;padding-top:8px;padding-right:18px;padding-bottom:8px;padding-left:18px;" data-attrs-event="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}" data-step="next" role="button" tabindex="0">
-                        Next
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div>
+          <style>
+          </style>
+          <a data-attrs-event="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}">
+            Next
+          </a>
         </div>
         """)
       )

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -443,6 +443,63 @@ defmodule FlokiTest do
 
     tree = document!(html_body("<span data-stuff=\"&quot;'\"></span>"))
     assert Floki.raw_html(tree) == expected_html
+
+    expected_html = ~S"""
+    <html>
+      <head>
+      </head>
+      <body>
+        <div class="canvas">
+          <div class="row-container">
+            <div class="row" style="display: flex;flex-wrap: wrap;width: 100%;">
+              <div class="zone-container" style="flex: 1;">
+                <div class="zone">
+                  <div class="zone-content">
+                    <div class="button-wrapper appcues-actions-right" style="width:100%;text-align:right;font-size:14px;margin-top:25px;margin-bottom:0px;">
+                      <style>
+                        .button-wrapper>[data-step=prev]::before {content: none} .button-wrapper>.appcues-button[data-step=next]::after {content: none}
+                      </style>
+                      <a class="appcues-button-success appcues-button" data-field-id="some_id" id="button-some_id" style="text-align:center;border:undefinedpx solid undefined;padding-top:8px;padding-right:18px;padding-bottom:8px;padding-left:18px;" data-attrs-event="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}" data-step="next" role="button" tabindex="0">
+                        Next
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+    """
+
+    tree =
+      document!(
+        html_body(~S"""
+        <div class="canvas">
+          <div class="row-container">
+            <div class="row" style="display: flex;flex-wrap: wrap;width: 100%;">
+              <div class="zone-container" style="flex: 1;">
+                <div class="zone">
+                  <div class="zone-content">
+                    <div class="button-wrapper appcues-actions-right" style="width:100%;text-align:right;font-size:14px;margin-top:25px;margin-bottom:0px;">
+                      <style>
+                        .button-wrapper>[data-step=prev]::before {content: none} .button-wrapper>.appcues-button[data-step=next]::after {content: none}
+                      </style>
+                      <a class="appcues-button-success appcues-button" data-field-id="some_id" id="button-some_id" style="text-align:center;border:undefinedpx solid undefined;padding-top:8px;padding-right:18px;padding-bottom:8px;padding-left:18px;" data-attrs-event="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}" data-step="next" role="button" tabindex="0">
+                        Next
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        """)
+      )
+
+    assert Floki.raw_html(tree, pretty: true) == expected_html
   end
 
   test "raw_html (with >)" do

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -450,7 +450,7 @@ defmodule FlokiTest do
       </head>
       <body>
         <div>
-          <style>
+          <style data-attrs-test="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}">
           </style>
           <a data-attrs-event="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}">
             Next
@@ -464,7 +464,7 @@ defmodule FlokiTest do
       document!(
         html_body(~S"""
         <div>
-          <style>
+          <style data-attrs-test="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}">
           </style>
           <a data-attrs-event="{&quot;event&quot;:&quot;buggy software&quot;,&quot;properties&quot;:{&quot;_builderButtonEvent&quot;:true}}">
             Next


### PR DESCRIPTION
Hi! We noticed a bug when going to upgrade Floki. It seems that any tag that is set to the `identity` encoder would propagate that encoder through the rest of the tree (instead of just to its' children). I've added a test case here taken from some real Appcues content that triggers this behavior. Without this fix, it's _very_ possible for Floki to emit broken HTML. If you parse any `script` or `style`, tag, the identity encoder would be applied, which would in this case, emit an un-escaped `data-attrs-event` tag (even if escaping is explicitly enabled!). I'm dubious on if it's the duty to handle not decoding the entities in the parser, but I'm 100% sure this is a bug as-is.