### PR TITLE
Implement parsing rules for the `:has` pseudo class selector

### DIFF
--- a/src/floki_selector_lexer.xrl
+++ b/src/floki_selector_lexer.xrl
@@ -6,6 +6,7 @@ QUOTED = (\"[^"]*\"|\'[^']*\')
 PARENTESIS = \([^)]*\)
 INT = [0-9]+
 NOT = (n|N)(o|O)(t|T)
+HAS = (h|H)(a|A)(s|S)
 ODD = (o|O)(d|D)(d|D)
 EVEN = (e|E)(v|V)(e|E)(n|N)
 PSEUDO_PATT = (\+|-)?({INT})?(n|N)((\+|-){INT})?
@@ -22,6 +23,7 @@ Rules.
 #{IDENTIFIER}                        : {token, {hash, TokenLine, unescape_inside_id_name(tail(TokenChars))}}.
 \.{IDENTIFIER}                       : {token, {class, TokenLine, unescape_inside_class_name(tail(TokenChars))}}.
 \:{NOT}\(                            : {token, {pseudo_not, TokenLine}}.
+\:{HAS}\(                            : {token, {pseudo_has, TokenLine}}.
 \:{IDENTIFIER}                       : {token, {pseudo, TokenLine, tail(TokenChars)}}.
 \({INT}\)                            : {token, {pseudo_class_int, TokenLine, list_to_integer(remove_wrapper(TokenChars))}}.
 \({ODD}\)                            : {token, {pseudo_class_odd, TokenLine}}.

--- a/test/floki/selector/parser_test.exs
+++ b/test/floki/selector/parser_test.exs
@@ -390,6 +390,40 @@ defmodule Floki.Selector.ParserTest do
            ]
   end
 
+  test "has pseudo-class - simple class" do
+    assert Parser.parse("a.foo:has(.bar)") == [
+             %Selector{
+               type: "a",
+               classes: ["foo"],
+               pseudo_classes: [%PseudoClass{name: "has", value: [%Selector{classes: ["bar"]}]}]
+             }
+           ]
+  end
+
+  test "has pseudo-class - using fl-contains pseudo class" do
+    assert Parser.parse("a.foo:has(:fl-contains('test'))") == [
+             %Selector{
+               type: "a",
+               classes: ["foo"],
+               pseudo_classes: [
+                 %PseudoClass{
+                   name: "has",
+                   value: [
+                     %Selector{
+                       pseudo_classes: [
+                         %Floki.Selector.PseudoClass{
+                           name: "fl-contains",
+                           value: "test"
+                         }
+                       ]
+                     }
+                   ]
+                 }
+               ]
+             }
+           ]
+  end
+
   test "warn unknown tokens" do
     assert capture_log(log_capturer("a { b")) =~
              ~r/module=Floki\.Selector\.Parser  Unknown token ('{'|~c"{")\. Ignoring/


### PR DESCRIPTION
Notice that we don't accept combinators yet. This is like the `:not()` selector.
This is related to the issue https://github.com/philss/floki/issues/482