### PR TITLE
feat: implement :has pseudo-selector functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,42 +235,49 @@ document
 
 Here you find all the [CSS selectors](https://www.w3.org/TR/selectors/#selectors) supported in the current version:
 
-| Pattern         | Description                  |
-|-----------------|------------------------------|
-| *               | any element                  |
-| E               | an element of type `E`       |
-| E[foo]          | an `E` element with a "foo" attribute |
-| E[foo="bar"]    | an E element whose "foo" attribute value is exactly equal to "bar" |
-| E[foo~="bar"]   | an E element whose "foo" attribute value is a list of whitespace-separated values, one of which is exactly equal to "bar" |
-| E[foo^="bar"]   | an E element whose "foo" attribute value begins exactly with the string "bar" |
-| E[foo$="bar"]   | an E element whose "foo" attribute value ends exactly with the string "bar" |
-| E[foo*="bar"]   | an E element whose "foo" attribute value contains the substring "bar" |
-| E[foo\|="en"]    | an E element whose "foo" attribute has a hyphen-separated list of values beginning (from the left) with "en" |
-| E:nth-child(n)  | an E element, the n-th child of its parent |
-| E:nth-last-child(n)  | an E element, the n-th child of its parent, counting from bottom to up |
-| E:first-child   | an E element, first child of its parent |
-| E:last-child   | an E element, last child of its parent |
-| E:nth-of-type(n)  | an E element, the n-th child of its type among its siblings |
-| E:nth-last-of-type(n)  | an E element, the n-th child of its type among its siblings, counting from bottom to up |
-| E:first-of-type   | an E element, first child of its type among its siblings |
-| E:last-of-type   | an E element, last child of its type among its siblings |
-| E:checked       | An E element (checkbox, radio, or option) that is checked |
-| E:disabled      | An E element (button, input, select, textarea, or option) that is disabled |
-| E.warning       | an E element whose class is "warning" |
-| E#myid          | an E element with ID equal to "myid" (for ids containing periods, use `#my\\.id` or `[id="my.id"]`) |
-| E:not(s)        | an E element that does not match simple selector s |
-| :root           | the root node or nodes (in case of fragments) of the document. Most of the times this is the `html` tag |
-| E F             | an F element descendant of an E element |
-| E > F           | an F element child of an E element |
-| E + F           | an F element immediately preceded by an E element |
-| E ~ F           | an F element preceded by an E element |
+| Pattern               | Description                                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| \*                    | any element                                                                                                                |
+| E                     | an element of type `E`                                                                                                     |
+| E[foo]                | an `E` element with a "foo" attribute                                                                                      |
+| E[foo="bar"]          | an E element whose "foo" attribute value is exactly equal to "bar"                                                         |
+| E[foo~="bar"]         | an E element whose "foo" attribute value is a list of whitespace-separated values, one of which is exactly equal to "bar"  |
+| E[foo^="bar"]         | an E element whose "foo" attribute value begins exactly with the string "bar"                                              |
+| E[foo$="bar"]         | an E element whose "foo" attribute value ends exactly with the string "bar"                                                |
+| E[foo*="bar"]         | an E element whose "foo" attribute value contains the substring "bar"                                                      |
+| E[foo\|="en"]         | an E element whose "foo" attribute has a hyphen-separated list of values beginning (from the left) with "en"               |
+| E:nth-child(n)        | an E element, the n-th child of its parent                                                                                 |
+| E:nth-last-child(n)   | an E element, the n-th child of its parent, counting from bottom to up                                                     |
+| E:first-child         | an E element, first child of its parent                                                                                    |
+| E:last-child          | an E element, last child of its parent                                                                                     |
+| E:nth-of-type(n)      | an E element, the n-th child of its type among its siblings                                                                |
+| E:nth-last-of-type(n) | an E element, the n-th child of its type among its siblings, counting from bottom to up                                    |
+| E:first-of-type       | an E element, first child of its type among its siblings                                                                   |
+| E:last-of-type        | an E element, last child of its type among its siblings                                                                    |
+| E:checked             | An E element (checkbox, radio, or option) that is checked                                                                  |
+| E:disabled            | An E element (button, input, select, textarea, or option) that is disabled                                                 |
+| E.warning             | an E element whose class is "warning"                                                                                      |
+| E#myid                | an E element with ID equal to "myid" (for ids containing periods, use `#my\\.id` or `[id="my.id"]`)                        |
+| E:not(s)              | an E element that does not match simple selector s                                                                         |
+| E:has(s)              | an E element that has a child element that matches simple selector s                                                       |
+| E:has(s1, s2)         | an E element that has a child element matching simple selector s1 and also has a child element matching simple selector s2 |
+| E:has(s1):has(s2)     | equivalent to E:has(s1, s2)                                                                                                |
+| :root                 | the root node or nodes (in case of fragments) of the document. Most of the times this is the `html` tag                    |
+| E F                   | an F element descendant of an E element                                                                                    |
+| E > F                 | an F element child of an E element                                                                                         |
+| E + F                 | an F element immediately preceded by an E element                                                                          |
+| E ~ F                 | an F element preceded by an E element                                                                                      |
 
 There are also some selectors based on non-standard specifications. They are:
 
 | Pattern               | Description                                                            |
-|-----------------------|------------------------------------------------------------------------|
+| --------------------- | ---------------------------------------------------------------------- |
 | E:fl-contains('foo')  | an E element that contains "foo" inside a text node                    |
 | E:fl-icontains('foo') | an E element that contains "foo" inside a text node (case insensitive) |
+
+### Simple selectors
+
+The pseudo-selectors `:has` and `:not` currently only support simple selectors. Simple selectors are all of the selectors except those that take another selector as an argument, so anything except `:not`, `:has`, `>`, `+` and `~`.
 
 ## Suppressing log messages
 
@@ -282,7 +289,7 @@ See https://hexdocs.pm/logger/Logger.html#module-compile-configuration for detai
 
 ## Special thanks
 
-* [@arasatasaygin](https://github.com/arasatasaygin) for Floki's logo from the [Open Logos project](http://openlogos.org/).
+- [@arasatasaygin](https://github.com/arasatasaygin) for Floki's logo from the [Open Logos project](http://openlogos.org/).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@
 Take this HTML as an example:
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<body>
-  <section id="content">
-    <p class="headline">Floki</p>
-    <span class="headline">Enables search using CSS selectors</span>
-    <a href="https://github.com/philss/floki">Github page</a>
-    <span data-model="user">philss</span>
-  </section>
-  <a href="https://hex.pm/packages/floki">Hex package</a>
-</body>
+  <body>
+    <section id="content">
+      <p class="headline">Floki</p>
+      <span class="headline">Enables search using CSS selectors</span>
+      <a href="https://github.com/philss/floki">Github page</a>
+      <span data-model="user">philss</span>
+    </section>
+    <a href="https://hex.pm/packages/floki">Hex package</a>
+  </body>
 </html>
 ```
 
@@ -235,38 +235,38 @@ document
 
 Here you find all the [CSS selectors](https://www.w3.org/TR/selectors/#selectors) supported in the current version:
 
-| Pattern               | Description                                                                                                                |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| \*                    | any element                                                                                                                |
-| E                     | an element of type `E`                                                                                                     |
-| E[foo]                | an `E` element with a "foo" attribute                                                                                      |
-| E[foo="bar"]          | an E element whose "foo" attribute value is exactly equal to "bar"                                                         |
-| E[foo~="bar"]         | an E element whose "foo" attribute value is a list of whitespace-separated values, one of which is exactly equal to "bar"  |
-| E[foo^="bar"]         | an E element whose "foo" attribute value begins exactly with the string "bar"                                              |
-| E[foo$="bar"]         | an E element whose "foo" attribute value ends exactly with the string "bar"                                                |
-| E[foo*="bar"]         | an E element whose "foo" attribute value contains the substring "bar"                                                      |
-| E[foo\|="en"]         | an E element whose "foo" attribute has a hyphen-separated list of values beginning (from the left) with "en"               |
-| E:nth-child(n)        | an E element, the n-th child of its parent                                                                                 |
-| E:nth-last-child(n)   | an E element, the n-th child of its parent, counting from bottom to up                                                     |
-| E:first-child         | an E element, first child of its parent                                                                                    |
-| E:last-child          | an E element, last child of its parent                                                                                     |
-| E:nth-of-type(n)      | an E element, the n-th child of its type among its siblings                                                                |
-| E:nth-last-of-type(n) | an E element, the n-th child of its type among its siblings, counting from bottom to up                                    |
-| E:first-of-type       | an E element, first child of its type among its siblings                                                                   |
-| E:last-of-type        | an E element, last child of its type among its siblings                                                                    |
-| E:checked             | An E element (checkbox, radio, or option) that is checked                                                                  |
-| E:disabled            | An E element (button, input, select, textarea, or option) that is disabled                                                 |
-| E.warning             | an E element whose class is "warning"                                                                                      |
-| E#myid                | an E element with ID equal to "myid" (for ids containing periods, use `#my\\.id` or `[id="my.id"]`)                        |
-| E:not(s)              | an E element that does not match simple selector s                                                                         |
-| E:has(s)              | an E element that has a child element that matches simple selector s                                                       |
-| E:has(s1, s2)         | an E element that has a child element matching simple selector s1 and also has a child element matching simple selector s2 |
-| E:has(s1):has(s2)     | equivalent to E:has(s1, s2)                                                                                                |
-| :root                 | the root node or nodes (in case of fragments) of the document. Most of the times this is the `html` tag                    |
-| E F                   | an F element descendant of an E element                                                                                    |
-| E > F                 | an F element child of an E element                                                                                         |
-| E + F                 | an F element immediately preceded by an E element                                                                          |
-| E ~ F                 | an F element preceded by an E element                                                                                      |
+| Pattern               | Description                                                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| \*                    | any element                                                                                                               |
+| E                     | an element of type `E`                                                                                                    |
+| E[foo]                | an `E` element with a "foo" attribute                                                                                     |
+| E[foo="bar"]          | an E element whose "foo" attribute value is exactly equal to "bar"                                                        |
+| E[foo~="bar"]         | an E element whose "foo" attribute value is a list of whitespace-separated values, one of which is exactly equal to "bar" |
+| E[foo^="bar"]         | an E element whose "foo" attribute value begins exactly with the string "bar"                                             |
+| E[foo$="bar"]         | an E element whose "foo" attribute value ends exactly with the string "bar"                                               |
+| E[foo*="bar"]         | an E element whose "foo" attribute value contains the substring "bar"                                                     |
+| E[foo\|="en"]         | an E element whose "foo" attribute has a hyphen-separated list of values beginning (from the left) with "en"              |
+| E:nth-child(n)        | an E element, the n-th child of its parent                                                                                |
+| E:nth-last-child(n)   | an E element, the n-th child of its parent, counting from bottom to up                                                    |
+| E:first-child         | an E element, first child of its parent                                                                                   |
+| E:last-child          | an E element, last child of its parent                                                                                    |
+| E:nth-of-type(n)      | an E element, the n-th child of its type among its siblings                                                               |
+| E:nth-last-of-type(n) | an E element, the n-th child of its type among its siblings, counting from bottom to up                                   |
+| E:first-of-type       | an E element, first child of its type among its siblings                                                                  |
+| E:last-of-type        | an E element, last child of its type among its siblings                                                                   |
+| E:checked             | An E element (checkbox, radio, or option) that is checked                                                                 |
+| E:disabled            | An E element (button, input, select, textarea, or option) that is disabled                                                |
+| E.warning             | an E element whose class is "warning"                                                                                     |
+| E#myid                | an E element with ID equal to "myid" (for ids containing periods, use `#my\\.id` or `[id="my.id"]`)                       |
+| E:not(s)              | an E element that does not match simple selector s                                                                        |
+| E:has(s)              | an E element that has a child element that matches simple selector s                                                      |
+| E:has(s1, s2)         | an E element that has a child element matching simple selector s1 OR s2                                                   |
+| E:has(s1):has(s2)     | An E element that has a child element matching simple selectors s1 AND s2                                                 |
+| :root                 | the root node or nodes (in case of fragments) of the document. Most of the times this is the `html` tag                   |
+| E F                   | an F element descendant of an E element                                                                                   |
+| E > F                 | an F element child of an E element                                                                                        |
+| E + F                 | an F element immediately preceded by an E element                                                                         |
+| E ~ F                 | an F element preceded by an E element                                                                                     |
 
 There are also some selectors based on non-standard specifications. They are:
 

--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -251,6 +251,10 @@ defmodule Floki.Selector do
     PseudoClass.match_root?(html_node, tree)
   end
 
+  defp pseudo_class_match?(html_node, pseudo_class = %{name: "has"}, tree) do
+    PseudoClass.match_has?(tree, html_node, pseudo_class)
+  end
+
   defp pseudo_class_match?(_html_node, %{name: unknown_pseudo_class}, _tree) do
     Logger.debug(fn ->
       "Pseudo-class #{inspect(unknown_pseudo_class)} is not implemented. Ignoring."

--- a/lib/floki/selector/parser.ex
+++ b/lib/floki/selector/parser.ex
@@ -300,8 +300,8 @@ defmodule Floki.Selector.Parser do
     %{pseudo_class | value: value}
   end
 
-  defp update_pseudo_with_inner_selector(_pseudo_class, _pseudo_with_inner_selector) do
-    Logger.debug("Only simple selectors are allowed in :not() pseudo-class. Ignoring.")
+  defp update_pseudo_with_inner_selector(%PseudoClass{name: name}, _pseudo_with_inner_selector) do
+    Logger.debug("Only simple selectors are allowed in :#{name}() pseudo-class. Ignoring.")
     nil
   end
 

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -153,8 +153,8 @@ defmodule Floki.Selector.PseudoClass do
   end
 
   def match_has?(tree, html_node, %__MODULE__{value: value} = pseudo_class) do
-    Enum.all?(value, fn inner_selector ->
-     Enum.any?(html_node.children_nodes_ids, fn id ->
+    Enum.any?(value, fn inner_selector ->
+      Enum.any?(html_node.children_nodes_ids, fn id ->
         child = Map.fetch!(tree.nodes, id)
 
         is_struct(child, HTMLNode) and

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -152,6 +152,20 @@ defmodule Floki.Selector.PseudoClass do
     html_node.node_id in tree.root_nodes_ids
   end
 
+  def match_has?(tree, html_node, %__MODULE__{value: value} = pseudo_class) do
+    value
+    |> Enum.all?(fn inner_selector ->
+      html_node.children_nodes_ids
+      |> Enum.any?(fn id ->
+        child = Map.get(tree.nodes, id)
+
+        child |> is_struct(HTMLNode) and
+          (child |> Floki.Selector.match?(inner_selector, tree) or
+             match_has?(tree, child, pseudo_class))
+      end)
+    end)
+  end
+
   defp node_position(ids, %HTMLNode{node_id: node_id}) do
     position = Enum.find_index(ids, fn id -> id == node_id end)
     position + 1

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -153,14 +153,12 @@ defmodule Floki.Selector.PseudoClass do
   end
 
   def match_has?(tree, html_node, %__MODULE__{value: value} = pseudo_class) do
-    value
-    |> Enum.all?(fn inner_selector ->
-      html_node.children_nodes_ids
-      |> Enum.any?(fn id ->
-        child = Map.get(tree.nodes, id)
+    Enum.all?(value, fn inner_selector ->
+     Enum.any?(html_node.children_nodes_ids, fn id ->
+        child = Map.fetch!(tree.nodes, id)
 
-        child |> is_struct(HTMLNode) and
-          (child |> Floki.Selector.match?(inner_selector, tree) or
+        is_struct(child, HTMLNode) and
+          (Floki.Selector.match?(child, inner_selector, tree) or
              match_has?(tree, child, pseudo_class))
       end)
     end)

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1,4 +1,5 @@
 defmodule FlokiTest do
+  @moduledoc false
   use ExUnit.Case, async: true
 
   doctest Floki
@@ -1574,6 +1575,314 @@ defmodule FlokiTest do
     assert_find(doc, ":root>body>div>div", [
       {"div", [], ["a"]},
       {"div", [], ["b"]}
+    ])
+  end
+
+  test "has pseudo-class simple" do
+    html =
+      """
+      <div>
+        <h1>Header</h1>
+        <p class="foo">some data</p>
+      </div>
+      <div>
+        <h2>Header 2</h2>
+        <img src="https://example.com"></img>
+      </div>
+      <div>
+        <h3>Header 3</h3>
+        <p class="bar">some data</p>
+      </div>
+      <div>
+        <img src="picture.jpg"></img>
+        <input type="checkbox" checked></input>
+      </div>
+      """
+      |> html_body()
+      |> document!()
+
+    assert_find(html, "div:has(h1)", [
+      {"div", [],
+       [
+         {"h1", [], ["Header"]},
+         {"p", [{"class", "foo"}], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "div:has(h2)", [
+      {"div", [],
+       [
+         {"h2", [], ["Header 2"]},
+         {"img", [{"src", "https://example.com"}], []}
+       ]}
+    ])
+
+    assert_find(html, "div:has(p)", [
+      {"div", [],
+       [
+         {"h1", [], ["Header"]},
+         {"p", [{"class", "foo"}], ["some data"]}
+       ]},
+      {"div", [],
+       [
+         {"h3", [], ["Header 3"]},
+         {"p", [{"class", "bar"}], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "div:has(p.foo)", [
+      {"div", [],
+       [
+         {"h1", [], ["Header"]},
+         {"p", [{"class", "foo"}], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "div:has(img[src='https://example.com'])", [
+      {"div", [],
+       [
+         {"h2", [], ["Header 2"]},
+         {"img", [{"src", "https://example.com"}], []}
+       ]}
+    ])
+
+    assert_find(html, "div:has(:checked)", [
+      {"div", [],
+       [
+         {"img", [{"src", "picture.jpg"}], []},
+         {"input", [{"type", "checkbox"}, {"checked", "checked"}], []}
+       ]}
+    ])
+  end
+
+  test "has pseudo-class with multiple selectors" do
+    html =
+      """
+      <div>
+        <h1>Header</h1>
+        <p>some data</p>
+      </div>
+      <div>
+        <h2>Header 2</h2>
+        <img src="https://example.com"></img>
+        <p>some data</p>
+      </div>
+      """
+      |> html_body()
+      |> document!()
+
+    assert_find(html, "div:has(h1, h2)", [])
+
+    assert_find(html, "div:has(h1, p)", [
+      {"div", [],
+       [
+         {"h1", [], ["Header"]},
+         {"p", [], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "div:has(h2, img, p)", [
+      {"div", [],
+       [
+         {"h2", [], ["Header 2"]},
+         {"img", [{"src", "https://example.com"}], []},
+         {"p", [], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "div:has(h1):has(p)", [
+      {"div", [],
+       [
+         {"h1", [], ["Header"]},
+         {"p", [], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "div:has(p):has(h1)", [
+      {"div", [],
+       [
+         {"h1", [], ["Header"]},
+         {"p", [], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "div:has(h2):has(img):has(p)", [
+      {"div", [],
+       [
+         {"h2", [], ["Header 2"]},
+         {"img", [{"src", "https://example.com"}], []},
+         {"p", [], ["some data"]}
+       ]}
+    ])
+  end
+
+  test "has pseudo-class with table" do
+    html =
+      """
+      <table>
+        <tbody>
+          <tr>
+            <h1>Header</h1>
+            <td>some data</td>
+          </tr>
+          <tr>
+            <th class="empty">No Label</th>
+            <td>some data</td>
+          </tr>
+          <tr>
+            <th><label>TEST</label></th>
+            <td>fetch me pls</td>
+            <div></div>
+          </tr>
+          <tr>
+            <th><div><label>NESTED</label></div></th>
+            <td><div>fetch me pls</div></td>
+          </tr>
+        </tbody>
+      </table>
+      """
+      |> html_body()
+      |> document!()
+
+    assert_find(html, "tr:has(label)", [
+      {"tr", [],
+       [
+         {"th", [], [{"label", [], ["TEST"]}]},
+         {"td", [], ["fetch me pls"]},
+         {"div", [], []}
+       ]},
+      {"tr", [],
+       [
+         {"th", [], [{"div", [], [{"label", [], ["NESTED"]}]}]},
+         {"td", [], [{"div", [], ["fetch me pls"]}]}
+       ]}
+    ])
+
+    assert_find(html, "tr:has(th.empty)", [
+      {"tr", [],
+       [
+         {"th", [{"class", "empty"}], ["No Label"]},
+         {"td", [], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "tr:has(h1, td)", [
+      {"tr", [],
+       [
+         {"h1", [], ["Header"]},
+         {"td", [], ["some data"]}
+       ]}
+    ])
+
+    assert_find(html, "tr:has(*:fl-contains('TEST'))", [
+      {"tr", [],
+       [
+         {"th", [], [{"label", [], ["TEST"]}]},
+         {"td", [], ["fetch me pls"]},
+         {"div", [], []}
+       ]}
+    ])
+
+    assert_find(html, "tr:has(label):has(div)", [
+      {"tr", [],
+       [
+         {"th", [], [{"label", [], ["TEST"]}]},
+         {"td", [], ["fetch me pls"]},
+         {"div", [], []}
+       ]},
+      {"tr", [],
+       [
+         {"th", [], [{"div", [], [{"label", [], ["NESTED"]}]}]},
+         {"td", [], [{"div", [], ["fetch me pls"]}]}
+       ]}
+    ])
+
+    ## NOTE: this parses incorrectly, parses as:
+    ##   %PseudoClass{name: "has", value: [%Selector{type: "label", pseudo_classes: [%PseudoClass{name: "has", value: []}]}]}
+    ## but would expect to parse as:
+    ##   %PseudoClass{name: "has", value: [%Selector{type: "div", pseudo_classes: [%PseudoClass{name: "has", value: [%Selector{type: "label"}]}]}]}
+    # assert_find(html, "tr:has(div:has(label))", [
+    #   {"tr", [],
+    #    [
+    #      {"th", [], [{"div", [], [{"label", [], ["NESTED"]}]}]},
+    #      {"td", [], [{"div", [], ["fetch me pls"]}]}
+    #    ]}
+    # ])
+
+    ## NOTE: this does not parse, because "only simple selectors are allowed in :has() pseudo-class"
+    # assert_find(html, "th:has(> label)", [
+    #   {"th", [], [{"label", [], ["TEST"]}]}
+    # ])
+
+    ## NOTE: this does not parse, because "only simple selectors are allowed in :has() pseudo-class"
+    # assert_find(html, "th:has(> div > label)", [
+    #   {"th", [], [{"div", [], [{"label", [], ["NESTED"]}]}]}
+    # ])
+
+    ## NOTE: this parses incorrectly, parses as:
+    ##  %PseudoClass{name: "not", value: [%Selector{type: "label", pseudo_classes: [%PseudoClass{name: "has", value: []}]}]}
+    ## but would expect to parse as:
+    ##  %PseudoClass{name: "not", value: [%Selector{type: "*", pseudo_classes: [%PseudoClass{name: "has", value: [%Selector{type: "label"}]}]}]}
+    # assert_find(html, "tr:not(:has(label))", [
+    #   {"tr", [], [{"th", [], ["No Label"]}, {"td", [], ["some data"]}]}
+    # ])
+  end
+
+  test "has pseudo-class edge-cases" do
+    html =
+      """
+      <div>
+        <div>
+          <div>foo</div>
+          <div>bar</div>
+        </div>
+        <div>baz</div>
+      </div>
+      """
+      |> html_body()
+      |> document!()
+
+    # `:has` without any selector matches all HTML nodes.
+    # Firefox ignores this case, warning of a bad selector due to a dangling combinator.
+    assert_find(html, "div:has()", [
+      {"div", [],
+       [
+         {"div", [], [{"div", [], ["foo"]}, {"div", [], ["bar"]}]},
+         {"div", [], ["baz"]}
+       ]},
+      {"div", [], [{"div", [], ["foo"]}, {"div", [], ["bar"]}]},
+      {"div", [], ["foo"]},
+      {"div", [], ["bar"]},
+      {"div", [], ["baz"]}
+    ])
+
+    # `:has` with * as the selector matches all HTML nodes with HTML nodes as children.
+    # This matches the behaviour of `:has(*)` in Firefox.
+    assert_find(html, "div:has(*)", [
+      {"div", [],
+       [
+         {"div", [], [{"div", [], ["foo"]}, {"div", [], ["bar"]}]},
+         {"div", [], ["baz"]}
+       ]},
+      {"div", [], [{"div", [], ["foo"]}, {"div", [], ["bar"]}]}
+    ])
+
+    # In this case, both the top-level div and the second-level div match the selector.
+    assert_find(html, "div:has(div:fl-contains('foo'))", [
+      {"div", [],
+       [
+         {"div", [],
+          [
+            {"div", [], ["foo"]},
+            {"div", [], ["bar"]}
+          ]},
+         {"div", [], ["baz"]}
+       ]},
+      {"div", [],
+       [
+         {"div", [], ["foo"]},
+         {"div", [], ["bar"]}
+       ]}
     ])
   end
 


### PR DESCRIPTION
Fixes #482, #382, #592  

TODO:
- [x] Add documentation for `:has` to README.
- [x] Review by @philss
- [x] Fix tests
- [x] Add a few more tests to include other combinators and sub-selectors.