### PR TITLE
Prevent `find/2` from crashing with empty selector

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -42,10 +42,15 @@ defmodule Floki.Finder do
 
   def find(html_tree, selector_as_string) when is_binary(selector_as_string) do
     selectors = Selector.Parser.parse(selector_as_string)
-    find(html_tree, selectors)
+
+    if selectors != [] do
+      find(html_tree, selectors)
+    else
+      []
+    end
   end
 
-  def find(html_tree, selector = %Selector{}) do
+  def find(html_tree, %Selector{} = selector) do
     find(html_tree, [selector])
   end
 

--- a/test/floki/selector/parser_test.exs
+++ b/test/floki/selector/parser_test.exs
@@ -431,4 +431,10 @@ defmodule Floki.Selector.ParserTest do
     assert capture_log(log_capturer("a + b@")) =~
              ~r/module=Floki\.Selector\.Parser  Unknown token ('@'|~c"@")\. Ignoring/
   end
+
+  test "empty selector" do
+    tokens = tokenize("")
+
+    assert Parser.parse(tokens) == []
+  end
 end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -1986,6 +1986,13 @@ defmodule FlokiTest do
              Floki.Finder.find(html_tree, [selector_struct_1, selector_struct_2])
   end
 
+  # Floki.find/2 - Empty case
+
+  test "find with an empty selector" do
+    html = document!(@html)
+    assert Floki.find(html, "") == []
+  end
+
   # Floki.get_by_id/2
 
   test "get_by_id finds element with special characters" do


### PR DESCRIPTION
Closes https://github.com/philss/floki/pull/605