### PR TITLE
Optimize multiple selectors deduping

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -76,8 +76,8 @@ defmodule Floki.Finder do
 
   def find(%HTMLTree{} = tree, selectors) when is_list(selectors) do
     Enum.flat_map(selectors, fn s -> traverse_html_tree(tree.node_ids, s, tree, []) end)
+    |> Enum.uniq_by(& &1.node_id)
     |> Enum.sort_by(& &1.node_id)
-    |> Enum.uniq()
   end
 
   # some selectors can be applied with the raw html tree tuples instead of


### PR DESCRIPTION
Use `Enum.uniq_by/2` with the `node_id` integer instead of relying on
`Enum.uniq/1`'s deep structural equality over large `HTMLNode`
structs.

Moving the de-duplication before the sort results in less elements
to be sorted, reducing the list that goes into the sort.

It's only 1-3% faster but it's also a simplification.