### PR TITLE
Fix docs inaccuracies

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -488,7 +488,7 @@ defmodule Floki do
       should be considered as text. Defaults to `false`.
 
     * `:style` - A boolean to control if the contents of `<style>` tags
-      should be considered as text. Defaults to `false`.
+      should be considered as text. Defaults to `true`.
 
     * `:sep` - A separator string that is added between text nodes.
       Defaults to `""`.

--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -230,7 +230,7 @@ defmodule Floki do
   defdelegate raw_html(html_tree, options \\ []), to: Floki.RawHTML
 
   @doc """
-  Find elements inside an HTML tree or string.
+  Find elements inside an HTML tree.
 
   ## Examples
 


### PR DESCRIPTION
Remove claim that `Floki.find` supports raw HTML strings
Correct default value for :style option in `Floki.text/2`
