### PR TITLE
Fix typespecs: remove binary from Floki.attribute/3 typespec

### DIFF
--- a/lib/floki.ex
+++ b/lib/floki.ex
@@ -614,7 +614,7 @@ defmodule Floki do
       ["e.corp"]
   """
 
-  @spec attribute(binary | html_tree | html_node, binary, binary) :: list
+  @spec attribute(html_tree | html_node, binary, binary) :: list
 
   def attribute(html, selector, attribute_name) do
     html


### PR DESCRIPTION
Binary as first arg no longer supported.