### PR TITLE
docs: update Mix.Config to import Config in HTMLParser docs

### DIFF
--- a/lib/floki/html_parser.ex
+++ b/lib/floki/html_parser.ex
@@ -10,7 +10,7 @@ defmodule Floki.HTMLParser do
 
   Or:
 
-      use Mix.Config
+      import Config
       config :floki, :html_parser, Floki.HTMLParser.Mochiweb
 
   The default parser is Mochiweb, which comes with Floki.


### PR DESCRIPTION
`use Mix.Config` is deprecated