### PR TITLE
Simplify class attribute matching

### DIFF
--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -168,9 +168,7 @@ defmodule Floki.Selector do
 
   defp do_classes_matches?(class_attr_value, classes) do
     if Enum.all?(classes, &String.contains?(class_attr_value, &1)) do
-      min_size = Enum.reduce(classes, -1, fn item, acc -> acc + 1 + bit_size(item) end)
-      can_match? = bit_size(class_attr_value) >= min_size
-      can_match? && classes -- String.split(class_attr_value, [" ", "\t", "\n"], trim: true) == []
+      classes -- String.split(class_attr_value, [" ", "\t", "\n"], trim: true) == []
     else
       false
     end


### PR DESCRIPTION
Due to previous new optimizations these lines of code now don't do anything for performance, in fact removing them makes the code slightly faster.