### PR TITLE
Optimize CSS class matching to avoid list subtraction

### DIFF
--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -168,7 +168,8 @@ defmodule Floki.Selector do
 
   defp do_classes_matches?(class_attr_value, classes) do
     if Enum.all?(classes, &String.contains?(class_attr_value, &1)) do
-      classes -- String.split(class_attr_value, [" ", "\t", "\n"], trim: true) == []
+      class_list = String.split(class_attr_value, [" ", "\t", "\n"], trim: true)
+      Enum.all?(classes, &(&1 in class_list))
     else
       false
     end

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -658,6 +658,7 @@ defmodule FlokiTest do
 
   test "find elements with duplicate classes in selector" do
     html = document!(html_body("<div class=\"button\"></div>"))
+
     assert_find(html, ".button.button", [
       {"div", [{"class", "button"}], []}
     ])

--- a/test/floki_test.exs
+++ b/test/floki_test.exs
@@ -656,6 +656,13 @@ defmodule FlokiTest do
     ])
   end
 
+  test "find elements with duplicate classes in selector" do
+    html = document!(html_body("<div class=\"button\"></div>"))
+    assert_find(html, ".button.button", [
+      {"div", [{"class", "button"}], []}
+    ])
+  end
+
   test "find elements with anormal class spacing" do
     html =
       document!(


### PR DESCRIPTION
Replaces list subtraction (--), which can be slow and behaves
incorrectly for duplicate classes in edge cases like '.a.a',
with an explicit string split and Enum.all?(&(&1 in class_list)).