### PR TITLE
Remove unused charref_html_after_buffer/2 clause

### DIFF
--- a/lib/floki/html/tokenizer.ex
+++ b/lib/floki/html/tokenizer.ex
@@ -2794,16 +2794,6 @@ defmodule Floki.HTML.Tokenizer do
     String.replace_prefix(buffer, candidate, "") <> html
   end
 
-  defp charref_html_after_buffer(
-         html,
-         s = %State{
-           charref_state: %CharrefState{candidate: candidate}
-         }
-       )
-       when is_binary(candidate) do
-    String.replace_prefix(IO.chardata_to_string(s.buffer), candidate, "") <> html
-  end
-
   defp charref_html_after_buffer(html, _), do: html
 
   # § tokenizer-numeric-character-reference-state


### PR DESCRIPTION
This fixes an Elixir 1.20.0-rc.4 compiler warning.

The s.buffer field is guaranteed to be a string (binary)
at the point charref_html_after_buffer/2 is called. This
was enforced by IO.chardata_to_string/1 inside seek_charref,
making the second clause of charref_html_after_buffer/2
entirely unreachable.
