### PR TITLE
Optimize iodata by avoiding empty separators in DeepText and FlatText

### DIFF
--- a/lib/floki/deep_text.ex
+++ b/lib/floki/deep_text.ex
@@ -17,6 +17,7 @@ defmodule Floki.DeepText do
   end
 
   defp get_text(text, [], _sep, _) when is_binary(text), do: text
+  defp get_text(text, acc, "", _) when is_binary(text), do: [acc, text]
   defp get_text(text, acc, sep, _) when is_binary(text), do: [acc, sep, text]
 
   defp get_text([], acc, _sep, _), do: acc

--- a/lib/floki/flat_text.ex
+++ b/lib/floki/flat_text.ex
@@ -48,6 +48,7 @@ defmodule Floki.FlatText do
   end
 
   defp text_from_node(text, [], _, _sep, _) when is_binary(text), do: text
+  defp text_from_node(text, acc, _, "", _) when is_binary(text), do: [acc, text]
   defp text_from_node(text, acc, _, sep, _) when is_binary(text), do: [acc, sep, text]
   defp text_from_node(_, acc, _, _, _), do: acc
 end


### PR DESCRIPTION
This change avoids the inclusion of empty strings in iodata. 
This results in a consistent 12-16% speedup and a ~23% reduction in memory usage.
