### PR TITLE
Simplify HTMLTree.build/1 by avoiding redundant build_tree calls

### DIFF
--- a/lib/floki/html_tree.ex
+++ b/lib/floki/html_tree.ex
@@ -74,37 +74,13 @@ defmodule Floki.HTMLTree do
         root_id = IDSeeder.seed(node_ids)
         root_node = %Text{content: text, node_id: root_id}
 
-        root_nodes_ids = [root_id | root_nodes_ids]
-        node_ids = [root_id | node_ids]
-
-        {node_ids, nodes} =
-          build_tree(
-            node_ids,
-            nodes,
-            [],
-            root_node,
-            []
-          )
-
-        {root_nodes_ids, node_ids, nodes}
+        {[root_id | root_nodes_ids], [root_id | node_ids], [{root_id, root_node} | nodes]}
 
       {:comment, comment}, {root_nodes_ids, node_ids, nodes} ->
         root_id = IDSeeder.seed(node_ids)
         root_node = %Comment{content: comment, node_id: root_id}
 
-        root_nodes_ids = [root_id | root_nodes_ids]
-        node_ids = [root_id | node_ids]
-
-        {node_ids, nodes} =
-          build_tree(
-            node_ids,
-            nodes,
-            [],
-            root_node,
-            []
-          )
-
-        {root_nodes_ids, node_ids, nodes}
+        {[root_id | root_nodes_ids], [root_id | node_ids], [{root_id, root_node} | nodes]}
 
       _, state ->
         state


### PR DESCRIPTION
Text and comment nodes are leaf nodes and therefore don't need the recursive
build_tree function. This change simplifies the code and provides
a small speedup during tree construction for these node types.
