### PR TITLE
Refactor: Optimize type matching in Selector using binary_part

### DIFF
--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -120,17 +120,13 @@ defmodule Floki.Selector do
       ^type ->
         true
 
-      type_maybe_with_namespace when byte_size(type_maybe_with_namespace) > byte_size(type) ->
-        expected_namespace_size = byte_size(type_maybe_with_namespace) - byte_size(type) - 1
+      type_maybe when is_binary(type_maybe) ->
+        type_size = byte_size(type)
+        node_size = byte_size(type_maybe)
 
-        Kernel.match?(
-          <<
-            _ns::binary-size(^expected_namespace_size),
-            ":",
-            ^type::binary
-          >>,
-          type_maybe_with_namespace
-        )
+        node_size > type_size and
+          binary_part(type_maybe, node_size - type_size - 1, 1) == ":" and
+          binary_part(type_maybe, node_size - type_size, type_size) == type
 
       _ ->
         false


### PR DESCRIPTION
Replace complex bitstring pattern matching for namespace type matching with a 0-allocation binary_part/3 implementation. This approach avoids extracting substrings at runtime, simplifying the code, improving execution speed, and reducing memory allocation.
