### PR TITLE
Refactor attribute retrieval functions for a 1.2-1.5x speedup

### DIFF
--- a/lib/floki/selector.ex
+++ b/lib/floki/selector.ex
@@ -283,11 +283,8 @@ defmodule Floki.Selector do
   defp attributes(%HTMLNode{type: :pi}), do: []
   defp attributes(%HTMLNode{attributes: attributes}), do: attributes
 
-  defp get_attribute_value(attributes, attribute_name) when is_list(attributes) do
-    :proplists.get_value(attribute_name, attributes, nil)
-  end
-
-  defp get_attribute_value(attributes, attribute_name) when is_map(attributes) do
-    Map.get(attributes, attribute_name)
-  end
+  defp get_attribute_value([{attr_name, value} | _], attr_name), do: value
+  defp get_attribute_value([_ | rest], attr_name), do: get_attribute_value(rest, attr_name)
+  defp get_attribute_value(attrs, attr_name) when is_map(attrs), do: Map.get(attrs, attr_name)
+  defp get_attribute_value(_, _), do: nil
 end

--- a/lib/floki/selector/attribute_selector.ex
+++ b/lib/floki/selector/attribute_selector.ex
@@ -135,22 +135,13 @@ defmodule Floki.Selector.AttributeSelector do
     s.attribute |> get_value(attributes) |> String.contains?(s.value)
   end
 
-  defp get_value(attr_name, attributes) when is_list(attributes) do
-    case List.keyfind(attributes, attr_name, 0) do
-      {^attr_name, value} -> value
-      nil -> ""
-    end
-  end
+  defp get_value(attr_name, [{attr_name, value} | _]), do: value
+  defp get_value(attr_name, [_ | rest]), do: get_value(attr_name, rest)
+  defp get_value(attr_name, attrs) when is_map(attrs), do: Map.get(attrs, attr_name, "")
+  defp get_value(_, _), do: ""
 
-  defp get_value(attr_name, attributes) when is_map(attributes) do
-    Map.get(attributes, attr_name, "")
-  end
-
-  defp attribute_present?(name, attributes) when is_list(attributes) do
-    List.keymember?(attributes, name, 0)
-  end
-
-  defp attribute_present?(name, attributes) when is_map(attributes) do
-    Map.has_key?(attributes, name)
-  end
+  defp attribute_present?(name, [{name, _} | _]), do: true
+  defp attribute_present?(name, [_ | rest]), do: attribute_present?(name, rest)
+  defp attribute_present?(name, attrs) when is_map(attrs), do: Map.has_key?(attrs, name)
+  defp attribute_present?(_, _), do: false
 end

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -111,39 +111,36 @@ defmodule Floki.Selector.PseudoClass do
   end
 
   def match_checked?(%{type: "input"} = html_node) do
-    attribute_is_present?(html_node.attributes, "checked")
+    attribute_present?(html_node.attributes, "checked")
   end
 
   def match_checked?(%{type: "option"} = html_node) do
-    attribute_is_present?(html_node.attributes, "selected")
+    attribute_present?(html_node.attributes, "selected")
   end
 
   def match_checked?({"input", attributes, _children}) do
-    attribute_is_present?(attributes, "checked")
+    attribute_present?(attributes, "checked")
   end
 
   def match_checked?({"option", attributes, _children}) do
-    attribute_is_present?(attributes, "selected")
+    attribute_present?(attributes, "selected")
   end
 
   def match_checked?(_), do: false
 
-  defp attribute_is_present?([{attr_name, _} | _], attr_name), do: true
-  defp attribute_is_present?([_ | rest], attr_name), do: attribute_is_present?(rest, attr_name)
-
-  defp attribute_is_present?(attrs, attr_name) when is_map(attrs),
-    do: not is_nil(attrs[attr_name])
-
-  defp attribute_is_present?(_, _), do: false
+  defp attribute_present?([{attr_name, _} | _], attr_name), do: true
+  defp attribute_present?([_ | rest], attr_name), do: attribute_present?(rest, attr_name)
+  defp attribute_present?(attrs, attr_name) when is_map(attrs), do: Map.has_key?(attrs, attr_name)
+  defp attribute_present?(_, _), do: false
 
   @disableable_html_nodes ~w[button input select option textarea]
 
   def match_disabled?(%{type: type} = html_node) when type in @disableable_html_nodes do
-    attribute_is_present?(html_node.attributes, "disabled")
+    attribute_present?(html_node.attributes, "disabled")
   end
 
   def match_disabled?({type, attributes, _children}) when type in @disableable_html_nodes do
-    attribute_is_present?(attributes, "disabled")
+    attribute_present?(attributes, "disabled")
   end
 
   def match_disabled?(_html_node), do: false

--- a/lib/floki/selector/pseudo_class.ex
+++ b/lib/floki/selector/pseudo_class.ex
@@ -128,13 +128,13 @@ defmodule Floki.Selector.PseudoClass do
 
   def match_checked?(_), do: false
 
-  defp attribute_is_present?(attributes, attribute_name) when is_list(attributes) do
-    match?({^attribute_name, _}, List.keyfind(attributes, attribute_name, 0))
-  end
+  defp attribute_is_present?([{attr_name, _} | _], attr_name), do: true
+  defp attribute_is_present?([_ | rest], attr_name), do: attribute_is_present?(rest, attr_name)
 
-  defp attribute_is_present?(attributes, attribute_name) when is_map(attributes) do
-    not is_nil(attributes[attribute_name])
-  end
+  defp attribute_is_present?(attrs, attr_name) when is_map(attrs),
+    do: not is_nil(attrs[attr_name])
+
+  defp attribute_is_present?(_, _), do: false
 
   @disableable_html_nodes ~w[button input select option textarea]
 


### PR DESCRIPTION
Replace `List.keyfind` / `keymember?` and `:proplists.get_value` with explicit pattern matching for improved performance.
