### PR TITLE
Optimize selector traversal

### DIFF
--- a/lib/floki/finder.ex
+++ b/lib/floki/finder.ex
@@ -319,7 +319,7 @@ defmodule Floki.Finder do
   end
 
   defp get_selector_nodes(%Selector.Combinator{match_type: :child}, html_node, _tree) do
-    Enum.reverse(html_node.children_nodes_ids)
+    html_node.children_nodes_ids
   end
 
   defp get_selector_nodes(%Selector.Combinator{match_type: :adjacent_sibling}, html_node, tree) do
@@ -373,7 +373,6 @@ defmodule Floki.Finder do
     case get_node(node_id, tree) do
       %{children_nodes_ids: children} when children != [] ->
         do_get_descendant_ids(children, tree, [])
-        |> Enum.reverse()
 
       _ ->
         []
@@ -383,16 +382,17 @@ defmodule Floki.Finder do
   defp do_get_descendant_ids([], _tree, acc), do: acc
 
   defp do_get_descendant_ids([node_id | rest], tree, acc) do
-    acc = do_get_descendant_ids(rest, tree, acc)
+    acc =
+      case get_node(node_id, tree) do
+        %{children_nodes_ids: children} when children != [] ->
+          do_get_descendant_ids(children, tree, acc)
+
+        _ ->
+          acc
+      end
+
     acc = [node_id | acc]
-
-    case get_node(node_id, tree) do
-      %{children_nodes_ids: children} when children != [] ->
-        do_get_descendant_ids(children, tree, acc)
-
-      _ ->
-        acc
-    end
+    do_get_descendant_ids(rest, tree, acc)
   end
 
   @spec map(Floki.html_tree() | Floki.html_node(), function()) ::


### PR DESCRIPTION
Avoid extra reversals while preserving descendant order.
