### PR TITLE
Fix Floki.text/2 when document contains a "PI" tag

### DIFF
--- a/lib/floki/deep_text.ex
+++ b/lib/floki/deep_text.ex
@@ -43,6 +43,7 @@ defmodule Floki.DeepText do
 
   defp get_text({"script", _, _}, acc, _, _, false, _), do: acc
   defp get_text({"style", _, _}, acc, _, _, _, false), do: acc
+  defp get_text({:pi, _, _}, acc, _, _, _, _), do: acc
 
   defp get_text({"input", attrs, _}, acc, _, true, _, _) do
     [acc, Floki.TextExtractor.extract_input_value(attrs)]

--- a/test/floki/deep_text_test.exs
+++ b/test/floki/deep_text_test.exs
@@ -106,4 +106,10 @@ defmodule Floki.DeepTextTest do
 
     assert Floki.DeepText.get(nodes) == "foo\nbaz"
   end
+
+  test "HTML that contains a processing instruction (<?xml ... ?>)" do
+    nodes = [{:pi, "", [{"indica", "indica"}]}, "foo"]
+
+    assert Floki.DeepText.get(nodes) == "foo"
+  end
 end

--- a/test/floki/flat_text_test.exs
+++ b/test/floki/flat_text_test.exs
@@ -123,4 +123,10 @@ defmodule Floki.FlatTextTest do
     assert Floki.FlatText.get([]) == ""
     assert Floki.FlatText.get({"div", [], []}) == ""
   end
+
+  test "HTML that contains a processing instruction (<?xml ... ?>)" do
+    nodes = [{:pi, "", [{"indica", "indica"}]}, "foo"]
+
+    assert Floki.FlatText.get(nodes) == "foo"
+  end
 end


### PR DESCRIPTION
This is a fix for when a processing instruction is inside the document tree (like a XML declaration).

Fixes https://github.com/philss/floki/issues/695